### PR TITLE
refactor: rename list variable to avoid shadowing built-in

### DIFF
--- a/DE/docs/scripting/lists.md
+++ b/DE/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Listen sind eine einfache Möglichkeit, mehrere Werte in einer einzigen Variablen zu speichern.
 Du kannst neue Listen so erstellen:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 Die Liste enthält jetzt die Werte `2`, `True` und `Items.Hay`.
 Eine Liste kann auch leer sein:
@@ -12,55 +12,55 @@ Eine Liste kann auch leer sein:
 Du kannst auf ein Element einer Liste über seinen Index zugreifen. Der Index ist `0` für das erste Element, `1` für das zweite Element, `2` für das dritte...
 
 _pflanzt Karotten_
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Du kannst mit einer for-Schleife über eine Liste iterieren. Das folgende Beispiel summiert alle Elemente in der Liste.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` ist jetzt `18`
 
 Die folgenden Listenmethoden ermöglichen es dir, Elemente hinzuzufügen und zu entfernen:
 
-`list.append(elem)` fügt ein Element am Ende der Liste hinzu:
+`elements.append(elem)` fügt ein Element am Ende der Liste hinzu:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` ist jetzt `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` ist jetzt `[2, 6, 12, 7]`
 
-`list.remove(elem)` entfernt das erste Vorkommen eines Elements aus einer Liste:
+`elements.remove(elem)` entfernt das erste Vorkommen eines Elements aus einer Liste:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` ist jetzt `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` ist jetzt `[1, 4, 2]`
 
-`list.insert(index, elem)` fügt ein Element am angegebenen Index ein:
+`elements.insert(index, elem)` fügt ein Element am angegebenen Index ein:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` ist jetzt `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` ist jetzt `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` entfernt das Element am angegebenen Index.
+`elements.pop(index)` entfernt das Element am angegebenen Index.
 Wenn kein Index angegeben wird, wird das letzte Element entfernt.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` ist jetzt `[3, 5, 8]`
-`list.pop(1)`
-`list` ist jetzt `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` ist jetzt `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` ist jetzt `[3, 8]`
 
 Die `len()`-Funktion gibt die Länge der Liste zurück.
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` ist jetzt `3`
 
 Listen haben Referenzsemantik. Das bedeutet, dass die Zuweisung einer Liste zu einer Variable dasselbe Listenobjekt dieser Variable zuweist, anstatt eine Kopie der Liste zu erstellen.
 Wenn zwei Variablen auf dieselbe Liste verweisen, werden Änderungen an der Liste von beiden gesehen.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` und `b` sind jetzt beide `[1]`

--- a/EN/docs/scripting/lists.md
+++ b/EN/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Lists are an easy way to store multiple values in a single variable.
 You can create new lists like this:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 The list now contains the values `2`, `True` and `Items.Hay`.
 A list can also be empty:
@@ -12,55 +12,55 @@ A list can also be empty:
 You can access an element of a list by its index. The index is `0` for the first element, `1` for the second element, `2` for the third...
 
 plants carrots
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 You can iterate over a list using a for loop. The following example sums the all elements in the list.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` is now `18`
 
 The following list methods allow you to add and remove elements:
 
-`list.append(elem)` adds an element to the end of the list:
+`elements.append(elem)` adds an element to the end of the list:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` is now `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` is now `[2, 6, 12, 7]`
 
-`list.remove(elem)` removes the first occurrence of an element from a list:
+`elements.remove(elem)` removes the first occurrence of an element from a list:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` is now `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` is now `[1, 4, 2]`
 
-`list.insert(index, elem)` inserts an element at the given index:
+`elements.insert(index, elem)` inserts an element at the given index:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` is now `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` is now `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` removes the element at the specified index.
+`elements.pop(index)` removes the element at the specified index.
 If no index is specified, the last item is removed.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` is now `[3, 5, 8]`
-`list.pop(1)`
-`list` is now `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` is now `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` is now `[3, 8]`
 
 The `len()` function returns the length of the list.
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` is now `3`
 
 Lists have reference semantics. This means that assigning a list to a variable assigns the same list object to that variable, rather than making a copy of the list.
 If two variables reference the same list, changes to the list will be seen by both.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` and `b` are now both `[1]`

--- a/ES/docs/scripting/lists.md
+++ b/ES/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Las listas son una forma fácil de almacenar múltiples valores en una sola variable.
 Puedes crear nuevas listas así:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 La lista ahora contiene los valores `2`, `True` y `Items.Hay`.
 Una lista también puede estar vacía:
@@ -12,55 +12,55 @@ Una lista también puede estar vacía:
 Puedes acceder a un elemento de una lista por su índice. El índice es `0` para el primer elemento, `1` para el segundo, `2` para el tercero...
 
 planta zanahorias
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Puedes iterar sobre una lista usando un bucle `for`. El siguiente ejemplo suma todos los elementos de la lista.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` ahora es `18`
 
 Los siguientes métodos de lista te permiten añadir y eliminar elementos:
 
-`list.append(elem)` añade un elemento al final de la lista:
+`elements.append(elem)` añade un elemento al final de la lista:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` ahora es `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` ahora es `[2, 6, 12, 7]`
 
-`list.remove(elem)` elimina la primera aparición de un elemento de una lista:
+`elements.remove(elem)` elimina la primera aparición de un elemento de una lista:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` ahora es `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` ahora es `[1, 4, 2]`
 
-`list.insert(index, elem)` inserta un elemento en el índice dado:
+`elements.insert(index, elem)` inserta un elemento en el índice dado:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` ahora es `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` ahora es `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` elimina el elemento en el índice especificado.
+`elements.pop(index)` elimina el elemento en el índice especificado.
 Si no se especifica ningún índice, se elimina el último ítem.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` ahora es `[3, 5, 8]`
-`list.pop(1)`
-`list` ahora es `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` ahora es `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` ahora es `[3, 8]`
 
 La función `len()` devuelve la longitud de la lista.
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` ahora es `3`
 
 Las listas tienen semántica de referencia. Esto significa que asignar una lista a una variable le asigna el mismo objeto de lista, en lugar de hacer una copia de la lista.
 Si dos variables hacen referencia a la misma lista, los cambios en la lista serán visibles para ambas.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` y `b` ahora son ambos `[1]`

--- a/FR/docs/scripting/lists.md
+++ b/FR/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Les listes sont un moyen facile de stocker plusieurs valeurs dans une seule variable.
 Tu peux créer de nouvelles listes comme ceci :
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 La liste contient maintenant les valeurs `2`, `True` et `Items.Hay`.
 Une liste peut aussi être vide :
@@ -12,55 +12,55 @@ Une liste peut aussi être vide :
 Tu peux accéder à un élément d'une liste par son index. L'index est `0` pour le premier élément, `1` pour le deuxième, `2` pour le troisième...
 
 plante des carottes
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Tu peux itérer sur une liste en utilisant une boucle for. L'exemple suivant additionne tous les éléments de la liste.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` est maintenant `18`
 
 Les méthodes de liste suivantes te permettent d'ajouter et de supprimer des éléments :
 
-`list.append(elem)` ajoute un élément à la fin de la liste :
+`elements.append(elem)` ajoute un élément à la fin de la liste :
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` est maintenant `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` est maintenant `[2, 6, 12, 7]`
 
-`list.remove(elem)` supprime la première occurrence d'un élément d'une liste :
+`elements.remove(elem)` supprime la première occurrence d'un élément d'une liste :
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` est maintenant `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` est maintenant `[1, 4, 2]`
 
-`list.insert(index, elem)` insère un élément à l'index donné :
+`elements.insert(index, elem)` insère un élément à l'index donné :
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` est maintenant `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` est maintenant `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` supprime l'élément à l'index spécifié.
+`elements.pop(index)` supprime l'élément à l'index spécifié.
 Si aucun index n'est spécifié, le dernier élément est supprimé.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` est maintenant `[3, 5, 8]`
-`list.pop(1)`
-`list` est maintenant `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` est maintenant `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` est maintenant `[3, 8]`
 
 La fonction `len()` renvoie la longueur de la liste.
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` est maintenant `3`
 
 Les listes ont une sémantique de référence. Cela signifie qu'assigner une liste à une variable assigne le même objet liste à cette variable, plutôt que de faire une copie de la liste.
 Si deux variables font référence à la même liste, les modifications apportées à la liste seront vues par les deux.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` et `b` sont maintenant tous les deux `[1]`

--- a/IT/docs/scripting/lists.md
+++ b/IT/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Le liste sono un modo semplice per memorizzare più valori in una singola variabile.
 Puoi creare nuove liste in questo modo:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 La lista ora contiene i valori `2`, `True` e `Items.Hay`.
 Una lista può anche essere vuota:
@@ -12,55 +12,55 @@ Una lista può anche essere vuota:
 Puoi accedere a un elemento di una lista tramite il suo indice. L'indice è `0` per il primo elemento, `1` per il secondo, `2` per il terzo...
 
 pianta carote
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Puoi iterare su una lista usando un ciclo for. L'esempio seguente somma tutti gli elementi nella lista.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` è ora `18`
 
 I seguenti metodi delle liste ti permettono di aggiungere e rimuovere elementi:
 
-`list.append(elem)` aggiunge un elemento alla fine della lista:
+`elements.append(elem)` aggiunge un elemento alla fine della lista:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` è ora `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` è ora `[2, 6, 12, 7]`
 
-`list.remove(elem)` rimuove la prima occorrenza di un elemento da una lista:
+`elements.remove(elem)` rimuove la prima occorrenza di un elemento da una lista:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` è ora `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` è ora `[1, 4, 2]`
 
-`list.insert(index, elem)` inserisce un elemento all'indice dato:
+`elements.insert(index, elem)` inserisce un elemento all'indice dato:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` è ora `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` è ora `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` rimuove l'elemento all'indice specificato.
+`elements.pop(index)` rimuove l'elemento all'indice specificato.
 Se non viene specificato alcun indice, viene rimosso l'ultimo elemento.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` è ora `[3, 5, 8]`
-`list.pop(1)`
-`list` è ora `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` è ora `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` è ora `[3, 8]`
 
 La funzione `len()` restituisce la lunghezza della lista.
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` è ora `3`
 
 Le liste hanno semantica per riferimento. Ciò significa che assegnare una lista a una variabile assegna lo stesso oggetto lista a quella variabile, invece di creare una copia della lista.
 Se due variabili fanno riferimento alla stessa lista, le modifiche alla lista saranno visibili da entrambe.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` e `b` sono ora entrambi `[1]`

--- a/JA/docs/scripting/lists.md
+++ b/JA/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 リストは、複数の値を1つの変数に簡単に格納する方法です。
 次のように新しいリストを作成できます:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 これでリストには `2`、`True`、`Items.Hay` の値が含まれます。
 リストは空にすることもできます:
@@ -12,55 +12,55 @@
 リストの要素にはインデックスでアクセスできます。インデックスは最初の要素が `0`、2番目の要素が `1`、3番目の要素が `2`...となります。
 
 ニンジンを植える
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 forループを使ってリストを反復処理できます。次の例では、リスト内のすべての要素を合計します。
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` は `18` になります。
 
 次のリストメソッドで要素を追加・削除できます:
 
-`list.append(elem)` はリストの末尾に要素を追加します:
+`elements.append(elem)` はリストの末尾に要素を追加します:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` は `[2, 6, 12, 7]` になります。
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` は `[2, 6, 12, 7]` になります。
 
-`list.remove(elem)` はリストから最初に現れる要素を削除します:
+`elements.remove(elem)` はリストから最初に現れる要素を削除します:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` は `[1, 4, 2]` になります。
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` は `[1, 4, 2]` になります。
 
-`list.insert(index, elem)` は指定されたインデックスに要素を挿入します:
+`elements.insert(index, elem)` は指定されたインデックスに要素を挿入します:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` は `[Entities.Tree, Items.Wood, Items.Hay]` になります。
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` は `[Entities.Tree, Items.Wood, Items.Hay]` になります。
 
-`list.pop(index)` は指定されたインデックスの要素を削除します。
+`elements.pop(index)` は指定されたインデックスの要素を削除します。
 インデックスが指定されていない場合、最後のアイテムが削除されます。
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` は `[3, 5, 8]` になります。
-`list.pop(1)`
-`list` は `[3, 8]` になります。
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` は `[3, 5, 8]` になります。
+`numbers.pop(1)`
+`numbers` は `[3, 8]` になります。
 
 `len()` 関数はリストの長さを返します。
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` は `3` になります。
 
 リストは参照セマンティクスを持ちます。これは、リストをコピーするのではなく、リストを同じリストオブジェクトに割り当てることを意味します。
 2つの変数が同じリストを参照している場合、リストへの変更は両方から見えます。
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` と `b` は両方とも `[1]` になります。

--- a/KO/docs/scripting/lists.md
+++ b/KO/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 리스트는 여러 값을 하나의 변수에 저장하는 쉬운 방법이에요.
 다음과 같이 새 리스트를 만들 수 있어요:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 이제 리스트는 `2`, `True`, `Items.Hay` 값을 포함해요.
 리스트는 비어 있을 수도 있어요:
@@ -12,45 +12,45 @@
 리스트의 요소는 인덱스로 접근할 수 있어요. 인덱스는 첫 번째 요소가 `0`, 두 번째 요소가 `1`, 세 번째 요소가 `2`... 이런 식이에요.
 
 당근을 심어요
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 for 루프를 사용하여 리스트를 반복할 수 있어요. 다음 예시는 리스트의 모든 요소를 합산해요.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum`은 이제 `18`이 돼요
 
 다음 리스트 메서드들을 사용하여 요소를 추가하고 제거할 수 있어요:
 
-`list.append(elem)`는 리스트의 끝에 요소를 추가해요:
+`elements.append(elem)`는 리스트의 끝에 요소를 추가해요:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list`는 이제 `[2, 6, 12, 7]`이 돼요
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers`는 이제 `[2, 6, 12, 7]`이 돼요
 
-`list.remove(elem)`는 리스트에서 요소의 첫 번째 항목을 제거해요:
+`elements.remove(elem)`는 리스트에서 요소의 첫 번째 항목을 제거해요:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list`는 이제 `[1, 4, 2]`가 돼요
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers`는 이제 `[1, 4, 2]`가 돼요
 
-`list.insert(index, elem)`는 주어진 인덱스에 요소를 삽입해요:
+`elements.insert(index, elem)`는 주어진 인덱스에 요소를 삽입해요:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list`는 이제 `[Entities.Tree, Items.Wood, Items.Hay]`가 돼요
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list`는 이제 `[Entities.Tree, Items.Wood, Items.Hay]`가 돼요
 
-`list.pop(index)`는 지정된 인덱스의 요소를 제거해요.
+`elements.pop(index)`는 지정된 인덱스의 요소를 제거해요.
 인덱스가 지정되지 않으면 마지막 항목이 제거돼요.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list`는 이제 `[3, 5, 8]`이 돼요
-`list.pop(1)`
-`list`는 이제 `[3, 8]`이 돼요
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers`는 이제 `[3, 5, 8]`이 돼요
+`numbers.pop(1)`
+`numbers`는 이제 `[3, 8]`이 돼요
 
 `len()` 함수는 리스트의 길이를 반환해요.
 `list = [3, 2, 1]
@@ -60,7 +60,7 @@ x = len(list)`
 리스트는 참조 의미론을 가져요. 이것은 리스트를 변수에 할당하면 리스트의 복사본을 만드는 대신 동일한 리스트 객체를 해당 변수에 할당한다는 의미예요.
 두 변수가 동일한 리스트를 참조하면, 리스트에 대한 변경 사항이 두 변수 모두에 반영돼요.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a`와 `b`는 이제 둘 다 `[1]`이 돼요

--- a/PL/docs/scripting/lists.md
+++ b/PL/docs/scripting/lists.md
@@ -2,65 +2,65 @@
 Listy to łatwy sposób na przechowywanie wielu wartości w jednej zmiennej.
 Możesz tworzyć nowe listy w ten sposób:
 
-`lista = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 Lista zawiera teraz wartości `2`, `True` i `Items.Hay`.
 Lista może być również pusta:
 
-`pusta_lista = []`
+`empty_list = []`
 
 Możesz uzyskać dostęp do elementu listy za pomocą jego indeksu. Indeks to `0` dla pierwszego elementu, `1` dla drugiego, `2` dla trzeciego...
 
 sadzi marchewki
-`lista = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(lista[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Możesz iterować po liście za pomocą pętli for. Poniższy przykład sumuje wszystkie elementy na liście.
 
-`lista = [4, 7, 2, 5]
-suma = 0
-for liczba in lista:
-	suma += liczba`
-`suma` wynosi teraz `18`
+`numbers = [4, 7, 2, 5]
+sum = 0
+for number in numbers:
+	sum += number`
+`sum` wynosi teraz `18`
 
 Poniższe metody list pozwalają na dodawanie i usuwanie elementów:
 
-`list.append(elem)` dodaje element na koniec listy:
+`elements.append(elem)` dodaje element na koniec listy:
 
-`lista = [2, 6, 12]
-lista.append(7)`
-`lista` to teraz `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` to teraz `[2, 6, 12, 7]`
 
-`list.remove(elem)` usuwa pierwsze wystąpienie elementu z listy:
+`elements.remove(elem)` usuwa pierwsze wystąpienie elementu z listy:
 
-`lista = [1, 2, 4, 2]
-lista.remove(2)`
-`lista` to teraz `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` to teraz `[1, 4, 2]`
 
-`list.insert(index, elem)` wstawia element na podanym indeksie:
+`elements.insert(index, elem)` wstawia element na podanym indeksie:
 
-`lista = [Entities.Tree, Items.Hay]
-lista.insert(1, Items.Wood)`
-`lista` to teraz `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` to teraz `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` usuwa element na określonym indeksie.
+`elements.pop(index)` usuwa element na określonym indeksie.
 Jeśli nie podano indeksu, usuwany jest ostatni element.
 
-`lista = [3, 5, 8, 25]
-lista.pop()`
-`lista` to teraz `[3, 5, 8]`
-`lista.pop(1)`
-`lista` to teraz `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` to teraz `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` to teraz `[3, 8]`
 
 Funkcja `len()` zwraca długość listy.
-`lista = [3, 2, 1]
-x = len(lista)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` wynosi teraz `3`
 
 Listy mają semantykę referencji. Oznacza to, że przypisanie listy do zmiennej przypisuje ten sam obiekt listy do tej zmiennej, zamiast tworzyć kopię listy.
 Jeśli dwie zmienne odnoszą się do tej samej listy, zmiany na liście będą widoczne dla obu.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` i `b` to teraz obie `[1]`

--- a/PT/docs/scripting/lists.md
+++ b/PT/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Listas são uma maneira fácil de armazenar múltiplos valores em uma única variável.
 Você pode criar novas listas assim:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 A lista agora contém os valores `2`, `True` e `Items.Hay`.
 Uma lista também pode estar vazia:
@@ -12,55 +12,55 @@ Uma lista também pode estar vazia:
 Você pode acessar um elemento de uma lista pelo seu índice. O índice é `0` para o primeiro elemento, `1` para o segundo, `2` para o terceiro...
 
 planta cenouras
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Você pode iterar sobre uma lista usando um loop for. O exemplo a seguir soma todos os elementos da lista.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` agora é `18`
 
 Os seguintes métodos de lista permitem que você adicione e remova elementos:
 
-`list.append(elem)` adiciona um elemento ao final da lista:
+`elements.append(elem)` adiciona um elemento ao final da lista:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` agora é `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` agora é `[2, 6, 12, 7]`
 
-`list.remove(elem)` remove a primeira ocorrência de um elemento de uma lista:
+`elements.remove(elem)` remove a primeira ocorrência de um elemento de uma lista:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` agora é `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` agora é `[1, 4, 2]`
 
-`list.insert(index, elem)` insere um elemento no índice fornecido:
+`elements.insert(index, elem)` insere um elemento no índice fornecido:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` agora é `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` agora é `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` remove o elemento no índice especificado.
+`elements.pop(index)` remove o elemento no índice especificado.
 Se nenhum índice for especificado, o último item é removido.
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` agora é `[3, 5, 8]`
-`list.pop(1)`
-`list` agora é `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` agora é `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` agora é `[3, 8]`
 
 A função `len()` retorna o comprimento da lista.
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` agora é `3`
 
 Listas têm semântica de referência. Isso significa que atribuir uma lista a uma variável atribui o mesmo objeto de lista a essa variável, em vez de fazer uma cópia da lista.
 Se duas variáveis fazem referência à mesma lista, as alterações na lista serão vistas por ambas.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` e `b` são agora ambos `[1]`

--- a/RU/docs/scripting/lists.md
+++ b/RU/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 Список — это простой способ хранить несколько значений в одной переменной.
 Ты можешь создавать новые списки так:
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 Этот список содержит значения `2`, `True` и `Items.Hay`.
 Список может быть пустым:
@@ -12,55 +12,55 @@
 Ты можешь получить доступ к элементу списка по его индексу. Индекс первого элемента — `0`, второго — `1`, третьего — `2` и так далее.
 
 Сажает морковь:
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 Ты можешь перебирать список с помощью цикла `for`. Следующий пример суммирует все элементы в списке.
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` теперь равно `18`.
 
 Следующие методы списка позволяют добавлять и удалять элементы.
 
-`list.append(elem)` добавляет элемент в конец списка:
+`elements.append(elem)` добавляет элемент в конец списка:
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` теперь `[2, 6, 12, 7]`.
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` теперь `[2, 6, 12, 7]`.
 
-`list.remove(elem)` удаляет первое вхождение элемента из списка:
+`elements.remove(elem)` удаляет первое вхождение элемента из списка:
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` теперь `[1, 4, 2]`.
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` теперь `[1, 4, 2]`.
 
-`list.insert(index, elem)` вставляет элемент по указанному индексу:
+`elements.insert(index, elem)` вставляет элемент по указанному индексу:
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` теперь `[Entities.Tree, Items.Wood, Items.Hay]`.
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` теперь `[Entities.Tree, Items.Wood, Items.Hay]`.
 
-`list.pop(index)` удаляет элемент по указанному индексу.
+`elements.pop(index)` удаляет элемент по указанному индексу.
 Если индекс не указан, удаляется последний элемент:
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` теперь `[3, 5, 8]`.
-`list.pop(1)`
-`list` теперь `[3, 8]`.
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` теперь `[3, 5, 8]`.
+`numbers.pop(1)`
+`numbers` теперь `[3, 8]`.
 
 Функция `len()` возвращает длину списка:
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` теперь `3`.
 
 Списки имеют ссылочную семантику. То есть, если переменной присваивается список, не создается его копия, а присваивается тот же самый объект-список.
 Если две переменные ссылаются на один и тот же список, изменения в нем будут видны обеим.
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` и `b` теперь оба равны `[1]`.

--- a/ZH/docs/scripting/lists.md
+++ b/ZH/docs/scripting/lists.md
@@ -2,7 +2,7 @@
 列表可以通过 1 个变量存储多个值。
 新列表的创建方式如下：
 
-`list = [2, True, Items.Hay]`
+`some_list = [2, True, Items.Hay]`
 
 这个列表现在包含了 `2`、`True` 和 `Items.Hay` 这些值。
 列表也可以是空的：
@@ -12,55 +12,55 @@
 你可以通过索引访问列表中的元素。第一个元素的索引是 `0`，第二个是 `1`，第三个是 `2`……
 
 种植胡萝卜
-`list = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
-plant(list[1])`
+`entities = [Entities.Tree, Entities.Carrot, Entities.Pumpkin]
+plant(entities[1])`
 
 你可以使用 for 循环迭代列表。下面的例子计算了列表中所有元素的和。
 
-`list = [4, 7, 2, 5]
+`numbers = [4, 7, 2, 5]
 sum = 0
-for number in list:
+for number in numbers:
 	sum += number`
 `sum` 现在是 `18`
 
 使用以下列表方法可添加和删除元素：
 
-`list.append(elem)` 在列表末尾添加 1 个元素：
+`elements.append(elem)` 在列表末尾添加 1 个元素：
 
-`list = [2, 6, 12]
-list.append(7)`
-`list` 现在是 `[2, 6, 12, 7]`
+`numbers = [2, 6, 12]
+numbers.append(7)`
+`numbers` 现在是 `[2, 6, 12, 7]`
 
-`list.remove(elem)` 从列表中移除某个元素第一次出现的项：
+`elements.remove(elem)` 从列表中移除某个元素第一次出现的项：
 
-`list = [1, 2, 4, 2]
-list.remove(2)`
-`list` 现在是 `[1, 4, 2]`
+`numbers = [1, 2, 4, 2]
+numbers.remove(2)`
+`numbers` 现在是 `[1, 4, 2]`
 
-`list.insert(index, elem)` 在给定索引处插入 1 个元素：
+`elements.insert(index, elem)` 在给定索引处插入 1 个元素：
 
-`list = [Entities.Tree, Items.Hay]
-list.insert(1, Items.Wood)`
-`list` 现在是 `[Entities.Tree, Items.Wood, Items.Hay]`
+`some_list = [Entities.Tree, Items.Hay]
+some_list.insert(1, Items.Wood)`
+`some_list` 现在是 `[Entities.Tree, Items.Wood, Items.Hay]`
 
-`list.pop(index)` 移除指定索引处的元素。
+`elements.pop(index)` 移除指定索引处的元素。
 如果未指定索引，则移除最后一项。
 
-`list = [3, 5, 8, 25]
-list.pop()`
-`list` 现在是 `[3, 5, 8]`
-`list.pop(1)`
-`list` 现在是 `[3, 8]`
+`numbers = [3, 5, 8, 25]
+numbers.pop()`
+`numbers` 现在是 `[3, 5, 8]`
+`numbers.pop(1)`
+`numbers` 现在是 `[3, 8]`
 
 `len()` 函数返回列表的长度。
-`list = [3, 2, 1]
-x = len(list)`
+`numbers = [3, 2, 1]
+x = len(numbers)`
 `x` 现在是 `3`
 
 列表具有引用语义。也就是说，将 1 个列表赋给 1 个变量，会将相应的列表对象赋给该变量，而不是创建列表的副本。
 如果多个变量引用同一个列表，更改列表会同时影响这些变量。
 
-`a = [1,2]
+`a = [1, 2]
 b = a
 b.pop()`
 `a` 和 `b` 现在都是 `[1]`


### PR DESCRIPTION
## Summary

This pull request updates the sample code in the in-game help page "Lists" to avoid using the built-in identifier `list` as a variable name.

## Details

In the sample code, a variable was named `list`, which conflicts with  built-in `list()` constructor.
If beginners copy the example directly, the built-in function would be shadowed and become unusable.
To prevent confusion and promote good coding practices, the variable name has been changed to a safer, non-conflicting one.

## Note on Translation Guidelines

According to the repository’s Translation Guidelines, code sections are generally not meant to be modified, as changing them could break behavior or consistency across languages.
Although this change technically alters a code example, it was made for educational clarity and to prevent potential misuse.
If this violates the intent of the guideline, I am open to discussion or revision.

## Impact

- Improves clarity and prevents shadowing of built-in functions
- May require confirmation regarding adherence to translation policy

## Credit Request

If this pull request is accepted, I would like to be credited under the name "taigo nakajima"