### PR TITLE
Builtins: Optional classes, exposes more types, type safety

### DIFF
--- a/builtins.py
+++ b/builtins.py
@@ -10,7 +10,7 @@
 # - string -> builtins.str
 # - range_class -> builtins.range
 
-from typing import Self, Literal, Final, overload
+from typing import Self, TypeVar, Literal, Final, overload
 from collections.abc import Callable, Iterable, Sequence, Container
 
 from builtins import (
@@ -83,6 +83,8 @@ included:
   - `Hats`, `Entities`, `Items`, `Grounds`, `Leaderboards`, `Unlocks`
 """
 
+_Hashable_ = TypeVar("_Hashable_", Hashable, Hashable, covariant = True)
+
 # --------------------------------------------------
 type Any = (
     Primitive | 								# Python builtin    - basic types
@@ -110,6 +112,8 @@ included:
   - `Hat`, `Entity`, `Item`, `Ground`, `Leaderboard`, `Unlock`
   - `Hats`, `Entities`, `Items`, `Grounds`, `Leaderboards`, `Unlocks`
 """
+
+_Any_ = TypeVar("_Any_", Any, Any, covariant = True)
 
 # --------------------------------------------------
 type AnyIterable = (
@@ -526,7 +530,149 @@ def range(start: _float, stop: _float, step: _float) -> range_class:  # type: ig
 	...
 
 # --------------------------------------------------
-def remove(collection: _list[Any] | _set[Hashable] | Sequence[Any] | Container[Hashable], object: Any):
+"""
+The following definitions are functions that mirror the methods that `lists`, `sets`, and `dicts` have. These definitions can be used as both a method and a function in TFWR.
+
+example usage (method):
+
+```
+list_numbers = [1, 2, 3]
+last_number = list_numbers.pop()
+print(last_number)
+```
+
+example usage (function):
+
+```
+list_numbers = [1, 2, 3]
+last_number = pop(list_numbers)
+print(last_number)
+```
+"""
+
+# --------------------------------------------------
+def add(given_set: _set[_Hashable_], object: Any):
+	"""
+	Add the `object` to a `given_set`.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	my_set = {1, 2, 3}
+	my_set.add(4)
+	print(my_set)
+	```
+
+	Output:
+
+	```
+	{1,2,3,4}
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def append(given_list: _list[_Any_], object: Any):
+	"""
+	Add `object` to the end of a list provided as `given_list`.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	my_list.append(4)
+	print(my_list)
+	```
+
+	Output:
+
+	```
+	[1,2,3,4]
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def insert(given_list: _list[_Any_], index: _int, object: Any):
+	"""
+	Add a `object` to the specified `index` to a list provided as `given_list`.
+
+	takes `1 + len(list) - index` ticks to execute
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	my_list.insert(1, 4)
+	print(my_list)
+	```
+
+	Output:
+
+	```
+	[1,4,2,3]
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def len(object : string | _dict[_Hashable_, _Any_] | _list[_Any_] | _set[_Hashable_] | _tuple[_Any_]) -> _int:
+	"""
+	Returns the number of items in the dict, list, set or str provided as `collection`.
+
+	returns the length of the dict, list, set or str.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	length = len(my_list)
+	print(length)
+	```
+
+	Output:
+
+	```
+	3
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def pop(collection: _dict[_Hashable_, _Any_] | _list[_Any_], object: Any):
+	"""
+	Remove the element corresponding to the `key` in a dict or list provided as `collection`. If it is a list and no `key` is specified removes the last element in the list.
+
+	returns the value of the removed element
+
+	takes `len(list) - index` ticks to execute if an index is provided
+	takes `1` tick to execute if no `key` is provided, of if a dict is provided
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	print("Old Value:", my_list.pop(1))
+	print("Current List:", my_list)
+	```
+
+	Output:
+
+	```
+	Old Value: 2
+	Current List: [1,3]
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def remove(collection: _list[_Any_] | _set[_Hashable_], object: Any):
 	"""
 	Remove the element corresponding to the `object` in a list or set provided as `collection`.
 
@@ -572,148 +718,6 @@ def str(object: Any) -> string:
 	```
 
 	Note: if you wish to type hint a `str` variable use the alias `string` instead
-	"""
-	...
-
-# --------------------------------------------------
-"""
-The following definitions are functions that mirror the methods that `lists`, `sets`, and `dicts` have. These definitions can be used as both a method and a function in TFWR.
-
-example usage (method):
-
-```
-list_numbers = [1, 2, 3]
-last_number = list_numbers.pop()
-print(last_number)
-```
-
-example usage (function):
-
-```
-list_numbers = [1, 2, 3]
-last_number = pop(list_numbers)
-print(last_number)
-```
-"""
-
-# --------------------------------------------------
-def add(given_set: _set[Hashable] | Container[Hashable], object: Any):
-	"""
-	Add the `object` to a `given_set`.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	my_set = {1, 2, 3}
-	my_set.add(4)
-	print(my_set)
-	```
-
-	Output:
-
-	```
-	{1,2,3,4}
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def append(given_list: _list[Any] | Sequence[Any], object: Any):
-	"""
-	Add `object` to the end of a list provided as `given_list`.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	my_list.append(4)
-	print(my_list)
-	```
-
-	Output:
-
-	```
-	[1,2,3,4]
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def insert(given_list: _list[Any] | Sequence[Any], index: _int, object: Any):
-	"""
-	Add a `object` to the specified `index` to a list provided as `given_list`.
-
-	takes `1 + len(list) - index` ticks to execute
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	my_list.insert(1, 4)
-	print(my_list)
-	```
-
-	Output:
-
-	```
-	[1,4,2,3]
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def len(object : string | _dict[Hashable, Any] | _list[Any] | _set[Hashable] | _tuple[Any] | Sequence[Any] | Container[Hashable]) -> _int:
-	"""
-	Returns the number of items in the dict, list, set or str provided as `collection`.
-
-	returns the length of the dict, list, set or str.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	length = len(my_list)
-	print(length)
-	```
-
-	Output:
-
-	```
-	3
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def pop(collection: _dict[Hashable, Any] | _list[Any] | Sequence[Any] | Container[Hashable], object: Any):
-	"""
-	Remove the element corresponding to the `key` in a dict or list provided as `collection`. If it is a list and no `key` is specified removes the last element in the list.
-
-	returns the value of the removed element
-
-	takes `len(list) - index` ticks to execute if an index is provided
-	takes `1` tick to execute if no `key` is provided, of if a dict is provided
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	print("Old Value:", my_list.pop(1))
-	print("Current List:", my_list)
-	```
-
-	Output:
-
-	```
-	Old Value: 2
-	Current List: [1,3]
-	```
 	"""
 	...
 

--- a/builtins.py
+++ b/builtins.py
@@ -3,27 +3,722 @@
 
 # Contributed by @Noon, @KlingonDragon, @dieckie, @Flekay and @Zoroark-Zwart on the TFWR Discord server.
 
-from typing import Self, Any as _Any, overload
-from collections.abc import Iterable, Callable
-from builtins import (bool as _bool, int as _int, float as _float, str as _str,
-					  range as _range,
-					  tuple as _tuple, list as _list, set as _set, dict as _dict)
+# Expose some useful types to allow for typing without using a typing import.
+# Typing imports would fail to run in-game as they are not ignored.
 
-type Any = (
-    _bool | _int | _float | _str | _range | # Python builtin    - basic types
+# Notes on aliases because of TFWR functions:
+# - string -> builtins.str
+# - range_class -> builtins.range
 
-	_tuple[Any] | _list[Any] |				# Python builtin    - collection types
-    _set[Any] | _dict[Any, Any] |
+from typing import Self, Literal, Final, overload
+from collections.abc import Callable, Iterable, Sequence, Container
 
-	Direction | Entity | Entities | 		# Game builtins		- enum classes
+from builtins import (
+    bool, int, float, str as string,
+    range as range_class,
+    tuple,
+
+    # If you uncomment the custom classes found below then
+    # comment this line to prevent conflicts
+    list, set, dict
+)
+
+# Used for when the builtin type is desirable over a possible
+# redefinition using the same name
+from builtins import (
+    bool as _bool, int as _int, float as _float,
+    tuple as _tuple, list as _list, set as _set, dict as _dict
+)
+
+from typing import Any as _Any
+
+# -------------------------------------------------------------------------------
+# Basic Types and Collections
+# -------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
+type Primitive = _bool | _int | _float | string | None
+"""
+Basic immutable types in TFWR.
+
+included:
+
+- `bool`
+- `int`
+- `float`
+- `string`
+- `None`
+"""
+
+type Enums = (
+	Direction | Entity | Entities |
     Ground | Grounds | Hat | Hats |
     Item | Items | Leaderboard |
-    Leaderboards | Unlock | Unlocks |
-
-	Drone |									# Game builtins		- megafarm classes
-
-    None									# Python builtin	- None
+    Leaderboards | Unlock | Unlocks
 )
+"""
+Type representing all available enums in TFWR.
+
+included:
+
+- `Direction` (`North`, `East`, `South`, `West`)
+- `Hat`, `Entity`, `Item`, `Ground`, `Leaderboard`, `Unlock`
+- `Hats`, `Entities`, `Items`, `Grounds`, `Leaderboards`, `Unlocks`
+"""
+
+# --------------------------------------------------
+type Hashable = Primitive | Enums | range_class | Drone | tuple[Hashable, ...]
+"""
+Type representing all of the useable types for a dict key or set element in TFWR.
+
+included:
+
+- Primitives: `bool`, `int`, `float`, `string`, `None`
+- `tuple` and tuples of tuples that use a `Hashable`
+- `range_class`, `function` (hinted as `Callable`)
+- `Drone` (from `spawn_drone`)
+- Enums:
+  - `Direction` (`North`, `East`, `South`, `West`)
+  - `Hat`, `Entity`, `Item`, `Ground`, `Leaderboard`, `Unlock`
+  - `Hats`, `Entities`, `Items`, `Grounds`, `Leaderboards`, `Unlocks`
+"""
+
+# --------------------------------------------------
+type Any = (
+    Primitive | 								# Python builtin    - basic types
+
+	range_class | Callable[..., Any] |			# Python builtin    - functions / modules
+
+	_tuple[Any,...] | _list[Any] |				# Python builtin    - collection types
+    _set[Hashable] | _dict[Hashable, Any] |
+
+	Enums | 									# Game builtins		- enum classes
+
+	Drone										# Game builtins		- megafarm classes
+)
+"""
+Type representing all of the useable types in TFWR.
+
+included:
+
+- Primitives: `bool`, `int`, `float`, `string`, `None`
+- `tuple`, `list`, `dict`, `set`
+- `range_class`, `module`, `function` (hinted as `Callable`)
+- `Drone` (from `spawn_drone`)
+- Enums:
+  - `Direction` (`North`, `East`, `South`, `West`)
+  - `Hat`, `Entity`, `Item`, `Ground`, `Leaderboard`, `Unlock`
+  - `Hats`, `Entities`, `Items`, `Grounds`, `Leaderboards`, `Unlocks`
+"""
+
+# --------------------------------------------------
+type AnyIterable = (
+	_dict[Hashable, Any] | _list[Any] | _set[Hashable] | _tuple[Any,...] |
+	string | range_class |
+	Entities | Grounds | Hats | Items | Leaderboard | Unlocks
+)
+"""
+Type representing all of the iterable types in TFWR.
+
+included:
+
+- `tuple`, `list`, `dict`, `set`
+- `string`, `range_class`
+- Enums:
+  - `Direction` (`North`, `East`, `South`, `West`)
+  - `Hat`, `Entity`, `Item`, `Ground`, `Leaderboard`, `Unlock`
+  - `Hats`, `Entities`, `Items`, `Grounds`, `Leaderboards`, `Unlocks`
+"""
+
+# --------------------------------------------------
+# Uncomment this class if you want additional game-specific type hints and docstrings for `dict` methods
+# This class requires the use of of the `dict()` constructor. Assigning `dict` literals (ex. `{'1':1, '1':2, '1':3}`) will cause typing conflicts with the builtin Python type `builtins.dict`
+
+# Comment out the `dict` builtins import above to prevent conflict errors.
+
+# class dict[key: Hashable, value: Any](_dict):
+# 	"""
+# 	Builds an unordered collection of key-value pairs
+
+# 	dict() -> new empty dictionary
+
+# 	dict(dictionary[keys, values]) -> new dictionary initialized from an existing `dictionary`
+
+# 	takes `1 + len(keys) + len(values)` ticks to execute if a dictionary is given.
+# 	takes `1` tick to execute if no input is given.
+# 	"""
+
+# 	def __init__(self: Self, input: _dict[Hashable, Any] | Container[Hashable] | None = None) -> None:
+# 		...
+
+# 	def len(self: Self) -> _int:
+# 		"""
+# 		Returns the number of items in the dictionary.
+
+# 		returns the length of the dictionary.
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_dict = {"One": 1, "Two": 2, "Three": 3}
+# 		length = len(my_dict)
+# 		print(length)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		3
+# 		```
+# 		"""
+# 		...
+
+# 	def pop(self: Self, key: Hashable) -> Any: # type: ignore
+# 		"""
+# 		Remove the key-value pair corresponding to the `key` in the dict
+
+# 		returns the value of the removed key-value pair
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_dict = {"One": 1, "Two": 2, "Three": 3}
+# 		print("Old Value:", my_dict.pop("One"))
+# 		print("Current Dict:", my_dict)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		Old Value: 1
+# 		Current Dict: {"Two":2,"Three":3}
+# 		```
+# 		"""
+# 		...
+# 	...
+
+
+# --------------------------------------------------
+# Uncomment this class if you want additional game-specific type hints and docstrings for `list` methods
+# This class requires the use of of the `list()` constructor. Assigning `list` literals (ex. `[1, 2, 3]`) will cause typing conflicts with the builtin Python type `builtins.list`
+
+# Comment out the `list` builtins import above to prevent conflict errors.
+
+# class list[value: Any](_list):
+# 	"""
+# 	Builds an ordered sequence of values.
+
+# 	list() -> new empty list
+
+# 	list(collection: list | tuple | set | str) -> new list from the values of the provided `collection`
+
+# 	list(collection: set | dict) -> new list from the keys of the given `collection`
+
+# 	list(game_enum) -> new list from the values of an in-game enumm `game_enum`
+
+# 	takes `1 + len(collection)` where `collection` is one of the above if an input is given.
+# 	takes `1` tick to execute if no input is given.
+# 	"""
+
+# 	def __init__(self: Self, input: AnyIterable | None = None) -> None:
+# 		...
+
+# 	def append(self: Self, object: Any) -> None:
+# 		"""
+# 		Add `object` to the end of a list provided as `given_list`.
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_list = [1, 2, 3]
+# 		my_list.append(4)
+# 		print(my_list)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		[1,2,3,4]
+# 		```
+# 		"""
+# 		...
+
+# 	def insert(self: Self, index: _int, object: Any) -> None: # type: ignore
+# 		"""
+# 		Add a `object` to the specified `index` to a list provided as `given_list`.
+
+# 		takes `1 + len(list) - index` ticks to execute
+
+# 		example usage:
+
+# 		```
+# 		my_list = [1, 2, 3]
+# 		my_list.insert(1, 4)
+# 		print(my_list)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		[1,4,2,3]
+# 		```
+# 		"""
+# 		...
+
+# 	def len(self: Self) -> _int:
+# 		"""
+# 		Returns the number of items in the list.
+
+# 		returns the length of the list.
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_list = [1, 2, 3]
+# 		length = len(my_list)
+# 		print(length)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		3
+# 		```
+# 		"""
+# 		...
+
+# 	def pop(self: Self, index: _int) -> Any: # type: ignore
+# 		"""
+# 		Remove the element corresponding to the `index` in the list. If no index is specified removes the last element in the list.
+
+# 		returns the value of the removed element
+
+# 		takes `len(list) - index` ticks to execute if an `index` is provided
+# 		takes `1` tick to execute if no `index` is provided
+
+# 		example usage:
+
+# 		```
+# 		my_list = [1, 2, 3]
+# 		print("Old Value:", my_list.pop(1))
+# 		print("Current List:", my_list)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		Old Value: 2
+# 		Current List: [1,3]
+# 		```
+# 		"""
+# 		...
+
+# 	def remove(self: Self, object: Any) -> None:
+# 		"""
+# 		Remove the element corresponding to the `object` in the list.
+
+# 		takes `num_comparions + num_shifts` ticks to execute
+
+# 		example usage:
+
+# 		```
+# 		my_list = [1, 2, 3]
+# 		my_list.remove(1)
+# 		print(my_list)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		[2,3]
+# 		```
+# 		"""
+# 		...
+# 	...
+
+
+# --------------------------------------------------
+# Uncomment this class if you want additional game-specific type hints and docstrings for `set` methods
+# This class requires the use of of the `set()` constructor. Assigning set literals (ex. `{1, 2, 3}`) will cause typing conflicts with the builtin Python type `builtins.set`
+
+# Comment out the `set` builtins import above to prevent conflict errors.
+
+# class set[value: Hashable](_set):
+# 	"""
+# 	Builds an unordered collection of elements
+
+# 	set() -> new empty set
+
+# 	set(collection: list | tuple | set | str) -> new set from the values of the provided `collection`
+
+# 	set(collection: set | dict) -> new set from the keys of the given `collection`
+
+# 	set(game_enum) -> new set from the values of an in-game enumm `game_enum`
+
+# 	takes `1 + len(collection)` where `collection` is one of the above if an input is given.
+# 	takes `1` tick to execute if no input is given.
+# 	"""
+
+# 	def __init__(self: Self, input: AnyIterable | None = None) -> None:
+# 		...
+
+# 	def add(self: Self, object: Any) -> None:
+# 		"""
+# 		Add the `object` to a `given_set`.
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_set = {1, 2, 3}
+# 		my_set.add(4)
+# 		print(my_set)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		{1,2,3,4}
+# 		```
+# 		"""
+# 		...
+
+# 	def len(self: Self) -> _int:
+# 		"""
+# 		Returns the number of items in the set.
+
+# 		returns the length of the set.
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_set = {1, 2, 3}
+# 		length = len(my_set)
+# 		print(length)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		3
+# 		```
+# 		"""
+# 		...
+
+# 	def remove(self: Self, object: Any) -> None:
+# 		"""
+# 		Remove the `object` from the set.
+
+# 		takes `1` tick to execute.
+
+# 		example usage:
+
+# 		```
+# 		my_set = {1, 2, 3}
+# 		my_set.remove(2)
+# 		print(my_set)
+# 		```
+
+# 		Output:
+
+# 		```
+# 		{1,3}
+# 		```
+# 		"""
+# 		...
+# 	...
+
+# -------------------------------------------------------------------------------
+@overload
+def range(stop: _float) -> range_class:  # type: ignore
+	"""
+	Returns a sequence of numbers from `0` (inclusive) to `stop` (exclusive).
+
+	returns a range object.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	for i in range(5):
+	    print(i)
+	```
+
+	Output:
+
+	```
+	0
+	1
+	2
+	3
+	4
+	```
+
+	Note: if you wish to type hint a `range` variable use the alias `range_class` instead
+	"""
+	...
+
+@overload
+def range(start: _float, stop: _float) -> range_class:  # type: ignore
+	"""
+	Returns a sequence of numbers from `start` (inclusive) to `stop` (exclusive).
+
+	returns a range object.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	for i in range(2, 5):
+	    print(i)
+	```
+
+	Output:
+
+	```
+	2
+	3
+	4
+	```
+
+	Note: if you wish to type hint a `range` variable use the alias `range_class` instead
+	"""
+	...
+
+@overload
+def range(start: _float, stop: _float, step: _float) -> range_class:  # type: ignore
+	"""
+	Returns a sequence of numbers from `start` (inclusive) to `stop` (exclusive) every `step` interval.
+
+	returns a range object.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	for i in range(2, 5, 2):
+	    print(i)
+	```
+
+	Output:
+
+	```
+	2
+	4
+	```
+
+	Note: if you wish to type hint a `range` variable use the alias `range_class` instead
+	"""
+	...
+
+# --------------------------------------------------
+def remove(collection: _list[Any] | _set[Hashable] | Sequence[Any] | Container[Hashable], object: Any):
+	"""
+	Remove the element corresponding to the `object` in a list or set provided as `collection`.
+
+	takes `num_comparions + num_shifts` ticks to execute if a list is provided.
+	takes `1` tick to execute if a set is provided.
+
+	example usage:
+
+	```
+	my_set = {1, 2, 3}
+	my_set.remove(2)
+	print(my_set)
+	```
+
+	Output:
+
+	```
+	{1,3}
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def str(object: Any) -> string:
+	"""
+	Converts an object to its string representation.
+
+	returns the string representation of the object.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	string = str(1000)
+	print(string)
+	```
+
+	Output:
+
+	```
+	"1000"
+	```
+
+	Note: if you wish to type hint a `str` variable use the alias `string` instead
+	"""
+	...
+
+# --------------------------------------------------
+"""
+The following definitions are functions that mirror the methods that `lists`, `sets`, and `dicts` have. These definitions can be used as both a method and a function in TFWR.
+
+example usage (method):
+
+```
+list_numbers = [1, 2, 3]
+last_number = list_numbers.pop()
+print(last_number)
+```
+
+example usage (function):
+
+```
+list_numbers = [1, 2, 3]
+last_number = pop(list_numbers)
+print(last_number)
+```
+"""
+
+# --------------------------------------------------
+def add(given_set: _set[Hashable] | Container[Hashable], object: Any):
+	"""
+	Add the `object` to a `given_set`.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	my_set = {1, 2, 3}
+	my_set.add(4)
+	print(my_set)
+	```
+
+	Output:
+
+	```
+	{1,2,3,4}
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def append(given_list: _list[Any] | Sequence[Any], object: Any):
+	"""
+	Add `object` to the end of a list provided as `given_list`.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	my_list.append(4)
+	print(my_list)
+	```
+
+	Output:
+
+	```
+	[1,2,3,4]
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def insert(given_list: _list[Any] | Sequence[Any], index: _int, object: Any):
+	"""
+	Add a `object` to the specified `index` to a list provided as `given_list`.
+
+	takes `1 + len(list) - index` ticks to execute
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	my_list.insert(1, 4)
+	print(my_list)
+	```
+
+	Output:
+
+	```
+	[1,4,2,3]
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def len(object : string | _dict[Hashable, Any] | _list[Any] | _set[Hashable] | _tuple[Any] | Sequence[Any] | Container[Hashable]) -> _int:
+	"""
+	Returns the number of items in the dict, list, set or str provided as `collection`.
+
+	returns the length of the dict, list, set or str.
+
+	takes `1` tick to execute.
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	length = len(my_list)
+	print(length)
+	```
+
+	Output:
+
+	```
+	3
+	```
+	"""
+	...
+
+# --------------------------------------------------
+def pop(collection: _dict[Hashable, Any] | _list[Any] | Sequence[Any] | Container[Hashable], object: Any):
+	"""
+	Remove the element corresponding to the `key` in a dict or list provided as `collection`. If it is a list and no `key` is specified removes the last element in the list.
+
+	returns the value of the removed element
+
+	takes `len(list) - index` ticks to execute if an index is provided
+	takes `1` tick to execute if no `key` is provided, of if a dict is provided
+
+	example usage:
+
+	```
+	my_list = [1, 2, 3]
+	print("Old Value:", my_list.pop(1))
+	print("Current List:", my_list)
+	```
+
+	Output:
+
+	```
+	Old Value: 2
+	Current List: [1,3]
+	```
+	"""
+	...
+
+
+
 
 # -------------------------------------------------------------------------------
 # In-Game Enums
@@ -675,562 +1370,6 @@ class Unlocks:
 
 
 # -------------------------------------------------------------------------------
-# Basic Types and Collections
-# -------------------------------------------------------------------------------
-
-# -------------------------------------------------------------------------------
-type AnyIterable = (
-	_dict[_Any, _Any] | _list[_Any] | _set[_Any] | _tuple[_Any] | _str |
-	Entities | Grounds | Hats | Items | Leaderboard | Unlocks
-)
-
-# --------------------------------------------------
-class dict[key: Any, value: Any](_dict):
-	"""
-	Builds an unordered collection of key-value pairs
-
-	dict() -> new empty dictionary
-
-	dict(dictionary[keys, values]) -> new dictionary initialized from an existing `dictionary`
-
-	takes `1 + len(keys) + len(values)` ticks to execute if a dictionary is given.
-	takes `1` tick to execute if no input is given.
-	"""
-
-	def __init__(self: Self, input: dict[Any, Any] | None = None) -> None:
-		...
-
-	def len(self: Self) -> _int:
-		"""
-		Returns the number of items in the dictionary.
-
-		returns the length of the dictionary.
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_dict = {"One": 1, "Two": 2, "Three": 3}
-		length = len(my_dict)
-		print(length)
-		```
-
-		Output:
-
-		```
-		3
-		```
-		"""
-		...
-
-	def pop(self: Self, key: Any) -> Any: # type: ignore
-		"""
-		Remove the key-value pair corresponding to the `key` in the dict
-
-		returns the value of the removed key-value pair
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_dict = {"One": 1, "Two": 2, "Three": 3}
-		print("Old Value:", my_dict.pop("One"))
-		print("Current Dict:", my_dict)
-		```
-
-		Output:
-
-		```
-		Old Value: 1
-		Current Dict: {"Two":2,"Three":3}
-		```
-		"""
-		...
-	...
-
-
-# --------------------------------------------------
-class list[index: Any](_list):
-	"""
-	Builds an ordered sequence of values.
-
-	list() -> new empty list
-
-	list(collection: list | tuple | set | str) -> new list from the values of the provided `collection`
-
-	list(collection: set | dict) -> new list from the keys of the given `collection`
-
-	list(game_enum) -> new list from the values of an in-game enumm `game_enum`
-
-	takes `1 + len(collection)` where `collection` is one of the above if an input is given.
-	takes `1` tick to execute if no input is given.
-	"""
-
-	def __init__(self: Self, input: AnyIterable | None = None) -> None:
-		...
-
-	def append(self: Self, object: Any) -> None:
-		"""
-		Add `object` to the end of a list provided as `given_list`.
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_list = [1, 2, 3]
-		my_list.append(4)
-		print(my_list)
-		```
-
-		Output:
-
-		```
-		[1,2,3,4]
-		```
-		"""
-		...
-
-	def insert(self: Self, index: _int, object: Any) -> None: # type: ignore
-		"""
-		Add a `object` to the specified `index` to a list provided as `given_list`.
-
-		takes `1 + len(list) - index` ticks to execute
-
-		example usage:
-
-		```
-		my_list = [1, 2, 3]
-		my_list.insert(1, 4)
-		print(my_list)
-		```
-
-		Output:
-
-		```
-		[1,4,2,3]
-		```
-		"""
-		...
-
-	def len(self: Self) -> _int:
-		"""
-		Returns the number of items in the list.
-
-		returns the length of the list.
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_list = [1, 2, 3]
-		length = len(my_list)
-		print(length)
-		```
-
-		Output:
-
-		```
-		3
-		```
-		"""
-		...
-
-	def pop(self: Self, index: _int) -> Any: # type: ignore
-		"""
-		Remove the element corresponding to the `index` in the list. If no index is specified removes the last element in the list.
-
-		returns the value of the removed element
-
-		takes `len(list) - index` ticks to execute if an `index` is provided
-		takes `1` tick to execute if no `index` is provided
-
-		example usage:
-
-		```
-		my_list = [1, 2, 3]
-		print("Old Value:", my_list.pop(1))
-		print("Current List:", my_list)
-		```
-
-		Output:
-
-		```
-		Old Value: 2
-		Current List: [1,3]
-		```
-		"""
-		...
-
-	def remove(self: Self, object: Any) -> None:
-		"""
-		Remove the element corresponding to the `object` in the list.
-
-		takes `num_comparions + num_shifts` ticks to execute
-
-		example usage:
-
-		```
-		my_list = [1, 2, 3]
-		my_list.remove(1)
-		print(my_list)
-		```
-
-		Output:
-
-		```
-		[2,3]
-		```
-		"""
-		...
-	...
-
-
-# --------------------------------------------------
-class set[key: Any](_set):
-	"""
-	Builds an unordered collection of elements
-
-	set() -> new empty set
-
-	set(collection: list | tuple | set | str) -> new set from the values of the provided `collection`
-
-	set(collection: set | dict) -> new set from the keys of the given `collection`
-
-	set(game_enum) -> new set from the values of an in-game enumm `game_enum`
-
-	takes `1 + len(collection)` where `collection` is one of the above if an input is given.
-	takes `1` tick to execute if no input is given.
-	"""
-
-	def __init__(self: Self, input: AnyIterable | None = None) -> None:
-		...
-
-	def add(self: Self, object: Any) -> None:
-		"""
-		Add the `object` to a `given_set`.
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_set = {1, 2, 3}
-		my_set.add(4)
-		print(my_set)
-		```
-
-		Output:
-
-		```
-		{1,2,3,4}
-		```
-		"""
-		...
-
-	def len(self: Self) -> _int:
-		"""
-		Returns the number of items in the set.
-
-		returns the length of the set.
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_set = {1, 2, 3}
-		length = len(my_set)
-		print(length)
-		```
-
-		Output:
-
-		```
-		3
-		```
-		"""
-		...
-
-	def remove(self: Self, object: Any) -> None:
-		"""
-		Remove the `object` from the set.
-
-		takes `1` tick to execute.
-
-		example usage:
-
-		```
-		my_set = {1, 2, 3}
-		my_set.remove(2)
-		print(my_set)
-		```
-
-		Output:
-
-		```
-		{1,3}
-		```
-		"""
-		...
-	...
-
-# -------------------------------------------------------------------------------
-def add(given_set: _set[Any], object: Any):
-	"""
-	Add the `object` to a `given_set`.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	my_set = {1, 2, 3}
-	my_set.add(4)
-	print(my_set)
-	```
-
-	Output:
-
-	```
-	{1,2,3,4}
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def append(given_list: _list[Any], object: Any):
-	"""
-	Add `object` to the end of a list provided as `given_list`.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	my_list.append(4)
-	print(my_list)
-	```
-
-	Output:
-
-	```
-	[1,2,3,4]
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def insert(given_list: _list[Any], index: _int, object: Any):
-	"""
-	Add a `object` to the specified `index` to a list provided as `given_list`.
-
-	takes `1 + len(list) - index` ticks to execute
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	my_list.insert(1, 4)
-	print(my_list)
-	```
-
-	Output:
-
-	```
-	[1,4,2,3]
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def len(object : _str | _dict[Any, Any] | _list[Any] | _set[Any] | _tuple[Any]) -> _int:
-	"""
-	Returns the number of items in the dict, list, set or str provided as `collection`.
-
-	returns the length of the dict, list, set or str.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	length = len(my_list)
-	print(length)
-	```
-
-	Output:
-
-	```
-	3
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def pop(collection: _dict[Any, Any] | _list[Any], object: Any):
-	"""
-	Remove the element corresponding to the `key` in a dict or list provided as `collection`. If it is a list and no `key` is specified removes the last element in the list.
-
-	returns the value of the removed element
-
-	takes `len(list) - index` ticks to execute if an index is provided
-	takes `1` tick to execute if no `key` is provided, of if a dict is provided
-
-	example usage:
-
-	```
-	my_list = [1, 2, 3]
-	print("Old Value:", my_list.pop(1))
-	print("Current List:", my_list)
-	```
-
-	Output:
-
-	```
-	Old Value: 2
-	Current List: [1,3]
-	```
-	"""
-	...
-
-# --------------------------------------------------
-@overload
-def range(stop: _float) -> _range:  # type: ignore
-	"""
-	Returns a sequence of numbers from `0` (inclusive) to `stop` (exclusive).
-
-	returns a range object.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	for i in range(5):
-	    print(i)
-	```
-
-	Output:
-
-	```
-	0
-	1
-	2
-	3
-	4
-	```
-	"""
-	...
-
-@overload
-def range(start: _float, stop: _float) -> _range:  # type: ignore
-	"""
-	Returns a sequence of numbers from `start` (inclusive) to `stop` (exclusive).
-
-	returns a range object.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	for i in range(2, 5):
-	    print(i)
-	```
-
-	Output:
-
-	```
-	2
-	3
-	4
-	```
-	"""
-	...
-
-@overload
-def range(start: _float, stop: _float, step: _float) -> _range:  # type: ignore
-	"""
-	Returns a sequence of numbers from `start` (inclusive) to `stop` (exclusive) every `step` interval.
-
-	returns a range object.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	for i in range(2, 5, 2):
-	    print(i)
-	```
-
-	Output:
-
-	```
-	2
-	4
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def remove(collection: _list[Any] | _set[Any], object: Any):
-	"""
-	Remove the element corresponding to the `object` in a list or set provided as `collection`.
-
-	takes `num_comparions + num_shifts` ticks to execute if a list is provided.
-	takes `1` tick to execute if a set is provided.
-
-	example usage:
-
-	```
-	my_set = {1, 2, 3}
-	my_set.remove(2)
-	print(my_set)
-	```
-
-	Output:
-
-	```
-	{1,3}
-	```
-	"""
-	...
-
-# --------------------------------------------------
-def str(object: Any) -> _str:
-	"""
-	Converts an object to its string representation.
-
-	returns the string representation of the object.
-
-	takes `1` tick to execute.
-
-	example usage:
-
-	```
-	string = str(1000)
-	print(string)
-	```
-
-	Output:
-
-	```
-	"1000"
-	```
-	"""
-	...
-
-
-
-
-# -------------------------------------------------------------------------------
 # Crop Management
 # -------------------------------------------------------------------------------
 
@@ -1849,10 +1988,10 @@ def set_world_size(size: _float) -> None:
 type SimulateUnlocks = _dict[Unlock, _int] | _tuple[_tuple[Unlock, _int]] | _list[_tuple[Unlock, _int]] | _tuple[Unlock] | _list[Unlock] | Unlocks
 
 def simulate(
-		filename: _str,
+		filename: string,
 		sim_unlocks: SimulateUnlocks,
 		sim_items: _dict[Item, _float],
-		sim_globals: _dict[_str, Any],
+		sim_globals: _dict[string, Any],
 		seed: _float, speedup: _float
 	) -> _float:
 	"""
@@ -1901,7 +2040,7 @@ def simulate(
 # -------------------------------------------------------------------------------
 
 # -------------------------------------------------------------------------------
-def get_cost(thing: Entity | Item | Unlock, level: _int | None = None) -> dict[Item, _int] | None:
+def get_cost(thing: Entity | Item | Unlock, level: _int | None = None) -> _dict[Item, _int] | None:
 	"""
 	Gets the cost of a `thing`
 
@@ -2051,7 +2190,7 @@ def abs(x: _float) -> _float:
 # -------------------------------------------------------------------------------
 
 # -------------------------------------------------------------------------------
-def print(*something: Any) -> None:
+def print(*something: _Any) -> None:
 	"""
 	Prints `something` into the air above the drone using smoke. This action is not affected by speed upgrades.
 	Multiple values can be printed at once.
@@ -2070,7 +2209,7 @@ def print(*something: Any) -> None:
 
 
 # --------------------------------------------------
-def quick_print(*something: Any) -> None:
+def quick_print(*something: _Any) -> None:
 	"""
 	Prints a value just like `print()` but it doesn't stop to write it into the air so it can only be found on the output page.
 
@@ -2132,7 +2271,7 @@ def pet_the_piggy() -> None:
 
 
 # --------------------------------------------------
-def leaderboard_run(leaderboard: Leaderboard, file_name: _str, speedup: _float) -> None:
+def leaderboard_run(leaderboard: Leaderboard, file_name: string, speedup: _float) -> None:
 	"""
 	Starts a timed run for the `leaderboard` using the specified `file_name` as a starting point.
 	`speedup` sets the starting speedup.

--- a/builtins.py
+++ b/builtins.py
@@ -2,6 +2,7 @@
 # Note that the games language is not Python and these definitions are only an approximation.
 
 # Contributed by @Noon, @KlingonDragon, @dieckie, @Flekay and @Zoroark-Zwart on the TFWR Discord server.
+# @SCD-3 on GitHub
 
 # Expose some useful types to allow for typing without using a typing import.
 # Typing imports would fail to run in-game as they are not ignored.
@@ -31,13 +32,13 @@ from builtins import (
 )
 
 from typing import Any as _Any
+from enum import Enum as _Enum, auto as _auto
 
 # -------------------------------------------------------------------------------
 # Basic Types and Collections
 # -------------------------------------------------------------------------------
 
 # -------------------------------------------------------------------------------
-type Primitive = _bool | _int | _float | string | None
 """
 Basic immutable types in TFWR.
 
@@ -49,7 +50,9 @@ included:
 - `string`
 - `None`
 """
+type Primitive = _bool | _int | _float | string | None
 
+# --------------------------------------------------
 type Enums = (
 	Direction | Entity | Entities |
     Ground | Grounds | Hat | Hats |
@@ -152,7 +155,7 @@ included:
 # 	takes `1` tick to execute if no input is given.
 # 	"""
 
-# 	def __init__(self: Self, input: _dict[Hashable, Any] | Container[Hashable] | None = None) -> None:
+# 	def __init__(self: Self, input: _dict[_Hashable_, _Any_] | None | Container[Hashable] = None) -> None:
 # 		...
 
 # 	def len(self: Self) -> _int:
@@ -767,13 +770,17 @@ class Entity:
 
 
 # --------------------------------------------------
-class Entities:
-	Apple: Entity
+class Entities(_Enum):
+	@staticmethod
+	def _generate_next_value_(name: string, start: _int, count: _int, last_values: _list[_Any]) -> Entity:
+		return Entity()
+
+	Apple = _auto()
 	"""
 	Dinosaurs love them apparently.
 	"""
 
-	Bush: Entity
+	Bush = _auto()
 	"""
 	A small bush that drops `Items.Wood`.
 
@@ -781,7 +788,7 @@ class Entities:
 	Grows on: grassland or soil
 	"""
 
-	Cactus: Entity
+	Cactus = _auto()
 	"""
 	Cacti come in 10 different sizes (0-9). When harvested, adjacent cacti that are in sorted order will also be harvested recursively.
 	You receive cactus equal to the number of harvested cacti squared.
@@ -790,7 +797,7 @@ class Entities:
 	Grows on: soil
 	"""
 
-	Carrot: Entity
+	Carrot = _auto()
 	"""
 	Carrots!
 
@@ -798,13 +805,13 @@ class Entities:
 	Grows on: soil
 	"""
 
-	Dead_Pumpkin: Entity
+	Dead_Pumpkin = _auto()
 	"""
 	One in five pumpkins dies when it grows up, leaving behind a dead pumpkin. Dead pumpkins are useless and disappear when something new is planted.
 	`can_harvest()` always returns `False` on dead pumpkins.
 	"""
 
-	Dinosaur: Entity
+	Dinosaur = _auto()
 	"""
 	A piece of the tail of the dinosaur hat. When wearing the dinosaur hat, the tail is dragged behind the drone filling previously moved tiles.
 
@@ -812,7 +819,7 @@ class Entities:
 	Grows on: grassland or soil
 	"""
 
-	Grass: Entity
+	Grass = _auto()
 	"""
 	Grows automatically on grassland. Harvest it to obtain `Items.Hay`.
 
@@ -820,12 +827,12 @@ class Entities:
 	Grows on: grassland or soil
 	"""
 
-	Hedge: Entity
+	Hedge = _auto()
 	"""
 	Part of the maze.
 	"""
 
-	Pumpkin: Entity
+	Pumpkin = _auto()
 	"""
 	Pumpkins grow together when they are next to other fully grown pumpkins. About 1 in 5 pumpkins dies when it grows up.
 	When you harvest a pumpkin you get `Items.Pumpkin` equal to the number of pumpkins in the mega pumpkin cubed.
@@ -834,7 +841,7 @@ class Entities:
 	Grows on: soil
 	"""
 
-	Sunflower: Entity
+	Sunflower = _auto()
 	"""
 	Sunflowers collect the power from the sun. Harvesting them will give you `Items.Power`.
 	If you harvest a sunflower with the maximum number of petals (and there are at least 10 sunflowers) you get 5x bonus power.
@@ -843,12 +850,12 @@ class Entities:
 	Grows on: soil
 	"""
 
-	Treasure: Entity
+	Treasure = _auto()
 	"""
 	A treasure that contains gold equal to the side length of the maze in which it is hidden. It can be harvested like a plant.
 	"""
 
-	Tree: Entity
+	Tree = _auto()
 	"""
 	Trees drop more wood than bushes. They take longer to grow if other trees grow next to them.
 
@@ -867,12 +874,16 @@ class Ground:
 
 # --------------------------------------------------
 class Grounds:
-	Grassland: Ground
+	@staticmethod
+	def _generate_next_value_(name: string, start: _int, count: _int, last_values: _list[_Any]) -> Ground:
+		return Ground()
+
+	Grassland = _auto()
 	"""
 	The default ground. Grass will automatically grow on it.
 	"""
 
-	Soil: Ground
+	Soil = _auto()
 	"""
 	Calling `till()` turns the ground into this. Calling `till()` again changes it back to grassland.
 	"""
@@ -888,132 +899,136 @@ class Hat:
 
 # --------------------------------------------------
 class Hats:
-	Brown_Hat: Hat
+	@staticmethod
+	def _generate_next_value_(name: string, start: _int, count: _int, last_values: _list[_Any]) -> Hat:
+		return Hat()
+
+	Brown_Hat = _auto()
 	"""
 	A brown hat.
 	"""
 
-	Cactus_Hat: Hat
+	Cactus_Hat = _auto()
 	"""
 	A hat shaped like a cactus.
 	"""
 
-	Carrot_Hat: Hat
+	Carrot_Hat = _auto()
 	"""
 	A hat shaped like a carrot.
 	"""
 
-	Dinosaur_Hat: Hat
+	Dinosaur_Hat = _auto()
 	"""
 	Equip it to start the dinosaur game.
 	"""
 
-	Gold_Hat: Hat
+	Gold_Hat = _auto()
 	"""
 	A golden hat.
 	"""
 
-	Gold_Trophy_Hat: Hat
+	Gold_Trophy_Hat = _auto()
 	"""
 	A golden trophy hat.
 	"""
 
-	Golden_Cactus_Hat: Hat
+	Golden_Cactus_Hat = _auto()
 	"""
 	A golden hat shaped like a cactus.
 	"""
 
-	Golden_Carrot_Hat: Hat
+	Golden_Carrot_Hat = _auto()
 	"""
 	A golden hat shaped like a carrot.
 	"""
 
-	Golden_Gold_Hat: Hat
+	Golden_Gold_Hat = _auto()
 	"""
 	A golden version of the gold hat.
 	"""
 
-	Golden_Pumpkin_Hat: Hat
+	Golden_Pumpkin_Hat = _auto()
 	"""
 	A golden hat shaped like a pumpkin.
 	"""
 
-	Golden_Sunflower_Hat: Hat
+	Golden_Sunflower_Hat = _auto()
 	"""
 	A golden hat shaped like a sunflower.
 	"""
 
-	Golden_Tree_Hat: Hat
+	Golden_Tree_Hat = _auto()
 	"""
 	A golden hat shaped like a tree.
 	"""
 
-	Gray_Hat: Hat
+	Gray_Hat = _auto()
 	"""
 	A gray hat.
 	"""
 
-	Green_Hat: Hat
+	Green_Hat = _auto()
 	"""
 	A green hat.
 	"""
 
-	Pumpkin_Hat: Hat
+	Pumpkin_Hat = _auto()
 	"""
 	A hat shaped like a pumpkin.
 	"""
 
-	Purple_Hat: Hat
+	Purple_Hat = _auto()
 	"""
 	A purple hat.
 	"""
 
-	Silver_Trophy_Hat: Hat
+	Silver_Trophy_Hat = _auto()
 	"""
 	A silver trophy hat.
 	"""
 
-	Straw_Hat: Hat
+	Straw_Hat = _auto()
 	"""
 	The default hat.
 	"""
 
-	Sunflower_Hat: Hat
+	Sunflower_Hat = _auto()
 	"""
 	A hat shaped like a sunflower.
 	"""
 
-	The_Farmers_Remains: Hat
+	The_Farmers_Remains = _auto()
 	"""
 	Unlocks the special hat 'The Farmers Remains'.
 	"""
 
-	Top_Hat: Hat
+	Top_Hat = _auto()
 	"""
 	Unlocks the fancy Top Hat.
 	"""
 
-	Traffic_Cone: Hat
+	Traffic_Cone = _auto()
 	"""
 	A traffic cone hat.
 	"""
 
-	Traffic_Cone_Stack: Hat
+	Traffic_Cone_Stack = _auto()
 	"""
 	A stack of traffic cones as a hat.
 	"""
 
-	Tree_Hat: Hat
+	Tree_Hat = _auto()
 	"""
 	A hat shaped like a tree.
 	"""
 
-	Wizard_Hat: Hat
+	Wizard_Hat = _auto()
 	"""
 	A magical wizard hat.
 	"""
 
-	Wood_Trophy_Hat: Hat
+	Wood_Trophy_Hat = _auto()
 	"""
 	A wooden trophy hat.
 	"""
@@ -1029,62 +1044,66 @@ class Item:
 
 # --------------------------------------------------
 class Items:
-    Bone: Item
+    @staticmethod
+    def _generate_next_value_(name: string, start: _int, count: _int, last_values: _list[_Any]) -> Item:
+        return Item()
+
+    Bone = _auto()
     """
     The bones of an ancient creature.
     """
 
-    Cactus: Item
+    Cactus = _auto()
     """
     Obtained by harvesting sorted cacti.
     """
 
-    Carrot: Item
+    Carrot = _auto()
     """
     Obtained by harvesting carrots.
     """
 
-    Fertilizer: Item
+    Fertilizer = _auto()
     """
     Call `use_item(Items.Fertilizer)` to instantly remove 2s from the plants remaining grow time.
     """
 
-    Gold: Item
+    Gold = _auto()
     """
     Found in treasure chests in mazes.
     """
 
-    Hay: Item
+    Hay = _auto()
     """
     Obtained by cutting grass.
     """
 
-    Piggy: Item
+    Piggy = _auto()
     """
     This item has been removed from the game but remains as a nostalgia trophy.
     """
 
-    Power: Item
+    Power = _auto()
     """
     Obtained by harvesting sunflowers. The drone automatically uses this to move twice as fast.
     """
 
-    Pumpkin: Item
+    Pumpkin = _auto()
     """
     Obtained by harvesting pumpkins.
     """
 
-    Water: Item
+    Water = _auto()
     """
     Used to water the ground by calling `use_item(Items.Water)`.
     """
 
-    Weird_Substance: Item
+    Weird_Substance = _auto()
     """
     Call `use_item(Items.Weird_Substance)` on a bush to grow a maze, or on other plants to toggle their infection status.
     """
 
-    Wood: Item
+    Wood = _auto()
     """
     Obtained from bushes and trees.
     """
@@ -1100,82 +1119,86 @@ class Leaderboard:
 
 # --------------------------------------------------
 class Leaderboards:
-	Cactus: Leaderboard
+	@staticmethod
+	def _generate_next_value_(name: string, start: _int, count: _int, last_values: _list[_Any]) -> Leaderboard:
+		return Leaderboard()
+
+	Cactus = _auto()
 	"""
 	Farm 33_554_432 cacti with multiple drones.
 	"""
 
-	Cactus_Single: Leaderboard
+	Cactus_Single = _auto()
 	"""
 	Farm 131_072_cacti with a single drone on an 8x8 farm.
 	"""
 
-	Carrots: Leaderboard
+	Carrots = _auto()
 	"""
 	Farm 2_000_000_000 carrots with multiple drones.
 	"""
 
-	Carrots_Single: Leaderboard
+	Carrots_Single = _auto()
 	"""
 	Farm 100_000_000 carrots with a single drone on an 8x8 farm.
 	"""
 
-	Dinosaur: Leaderboard
+	Dinosaur = _auto()
 	"""
 	Farm 33_488_928 bones with multiple drones.
 	"""
 
-	Fastest_Reset: Leaderboard
+	Fastest_Reset = _auto()
 	"""
 	The most prestigious category. Completely automate the game from a single farm plot to unlocking the leaderboards again.
 	"""
 
-	Hay: Leaderboard
+	Hay = _auto()
 	"""
 	Farm 2_000_000_000 hay with multiple drones.
 	"""
 
-	Hay_Single: Leaderboard
+	Hay_Single = _auto()
 	"""
 	Farm 100_000_000 hay with a single drone on an 8x8 farm.
 	"""
 
-	Maze: Leaderboard
+	Maze = _auto()
 	"""
 	Farm 9_863_168_gold with multiple drones.
 	"""
 
-	Maze_Single: Leaderboard
+	Maze_Single = _auto()
 	"""
 	Farm 616_448 gold with a single drone on an 8x8 farm.
 	"""
 
-	Pumpkins: Leaderboard
+	Pumpkins = _auto()
 	"""
 	Farm 200_000_000 pumpkins with multiple drones.
 	"""
 
-	Pumpkins_Single: Leaderboard
+	Pumpkins_Single = _auto()
 	"""
 	Farm 10_000_000 pumpkins with a single drone on an 8x8 farm.
 	"""
 
-	Sunflowers: Leaderboard
+	Sunflowers = _auto()
 	"""
 	Farm 100_000 power with multiple drones.
 	"""
 
-	Sunflowers_Single: Leaderboard
+	Sunflowers_Single = _auto()
 	"""
 	Farm 10_000 power with a single drone on an 8x8 farm.
 	"""
 
-	Wood: Leaderboard
+	Wood = _auto()
 	"""
 	Farm 10_000_000_000 wood with multiple drones.
 	"""
 
-	Wood_Single: Leaderboard
+	Wood_Single = _auto()
 	"""
 	Farm 500_000_000 wood with a single drone on an 8x8 farm.
 	"""
@@ -1191,180 +1214,184 @@ class Unlock:
 
 # --------------------------------------------------
 class Unlocks:
-	Auto_Unlock: Unlock
+	@staticmethod
+	def _generate_next_value_(name: string, start: _int, count: _int, last_values: _list[_Any]) -> Unlock:
+		return Unlock()
+
+	Auto_Unlock = _auto()
 	"""
 	Automatically unlock things.
 	"""
 
-	Cactus: Unlock
+	Cactus = _auto()
 	"""
 	Unlock: Cactus!
 	Upgrade: Increases the yield and cost of cactus.
 	"""
 
-	Carrots: Unlock
+	Carrots = _auto()
 	"""
 	Unlock: Till the soil and plant carrots.
 	Upgrade: Increases the yield and cost of carrots.
 	"""
 
-	Costs: Unlock
+	Costs = _auto()
 	"""
 	Allows access to the cost of things.
 	"""
 
-	Debug: Unlock
+	Debug = _auto()
 	"""
 	Tools to help with debugging programs.
 	"""
 
-	Debug_2: Unlock
+	Debug_2 = _auto()
 	"""
 	Functions to temporarily slow down the execution and make the grid smaller.
 	"""
 
-	Dictionaries: Unlock
+	Dictionaries = _auto()
 	"""
 	Get access to dictionaries and sets.
 	"""
 
-	Dinosaurs: Unlock
+	Dinosaurs = _auto()
 	"""
 	Unlock: Majestic ancient creatures.
 	Upgrade: Increases the yield and cost of dinosaurs.
 	"""
 
-	Expand: Unlock
+	Expand = _auto()
 	"""
 	Unlock: Expands the farm land and unlocks movement.
 	Upgrade: Expands the farm. This also clears the farm.
 	"""
 
-	Fertilizer: Unlock
+	Fertilizer = _auto()
 	"""
 	Reduces the remaining growing time of the plant under the drone by 2 seconds.
 	"""
 
-	Functions: Unlock
+	Functions = _auto()
 	"""
 	Define your own functions.
 	"""
 
-	Grass: Unlock
+	Grass = _auto()
 	"""
 	Increases the yield of grass.
 	"""
 
-	Hats: Unlock
+	Hats = _auto()
 	"""
 	Unlocks new hat colors for your drone.
 	"""
 
-	Import: Unlock
+	Import = _auto()
 	"""
 	Import code from other files.
 	"""
 
-	Leaderboard: Unlock
+	Leaderboard = _auto()
 	"""
 	Join the leaderboard for the fastest time in farming a specific crop or for the fastest reset of the farm.
 	"""
 
-	Lists: Unlock
+	Lists = _auto()
 	"""
 	Use lists to store lots of values.
 	"""
 
-	Loops: Unlock
+	Loops = _auto()
 	"""
 	Unlocks a simple while loop.
 	"""
 
-	Mazes: Unlock
+	Mazes = _auto()
 	"""
 	Unlock: A maze with a treasure in the middle.
 	Upgrade: Increases the gold in treasure chests.
 	"""
 
-	Megafarm: Unlock
+	Megafarm = _auto()
 	"""
 	Unlocks multiple drones and drone management functions.
 	"""
 
-	Operators: Unlock
+	Operators = _auto()
 	"""
 	Arithmetic, comparison and logic operators.
 	"""
 
-	Plant: Unlock
+	Plant = _auto()
 	"""
 	Unlocks planting.
 	"""
 
-	Polyculture: Unlock
+	Polyculture = _auto()
 	"""
 	Use companion planting to increase the yield.
 	"""
 
-	Pumpkins: Unlock
+	Pumpkins = _auto()
 	"""
 	Unlock: Pumpkins!
 	Upgrade: Increases the yield and cost of pumpkins.
 	"""
 
-	Senses: Unlock
+	Senses = _auto()
 	"""
 	The drone can see what's under it and where it is.
 	"""
 
-	Simulation: Unlock
+	Simulation = _auto()
 	"""
 	Unlocks simulation functions for testing and optimization.
 	"""
 
-	Speed: Unlock
+	Speed = _auto()
 	"""
 	Increases the speed of the drone.
 	"""
 
-	Sunflowers: Unlock
+	Sunflowers = _auto()
 	"""
 	Unlock: Sunflowers and Power.
 	Upgrade: Increases the power gained from sunflowers.
 	"""
 
-	The_Farmers_Remains: Unlock
+	The_Farmers_Remains = _auto()
 	"""
 	Unlocks the special hat 'The Farmers Remains'.
 	"""
 
-	Timing: Unlock
+	Timing = _auto()
 	"""
 	Functions to help measure performance.
 	"""
 
-	Top_Hat: Unlock
+	Top_Hat = _auto()
 	"""
 	Unlocks the fancy Top Hat.
 	"""
 
-	Trees: Unlock
+	Trees = _auto()
 	"""
 	Unlocks trees.
 	Upgrade: Increases the yield of bushes and trees.
 	"""
 
-	Utilities: Unlock
+	Utilities = _auto()
 	"""
 	Unlocks the `min()`, `max()` and `abs()` functions.
 	"""
 
-	Variables: Unlock
+	Variables = _auto()
 	"""
 	Assign values to variables.
 	"""
 
-	Watering: Unlock
+	Watering = _auto()
 	"""
 	Water the plants to make them grow faster.
 	"""


### PR DESCRIPTION
- Made custom classes optional as they can cause conflicts when using `[]` to initialize an empty list, `{}` to initialize a dict, and when trying to initialize with list, dict, and set literals. Added some comments to note why these classes are there.
- Added a comment explaining the method-as-function section
- Added new custom types for Primitives, Any and Hashable with comments explaining them
- Added covariant type vars in functions that a list, dict, or set of Any or Hashable
- Created a type alias for str -> string and range -> range_class to allow type hints where those types are shadowed by in-game functions
- Added notes about these aliases in the game function docstring
- Changed the dict in `get_cost` to use the type alias `_dict` instead of the potential custom class `dict` for compatibility
- Changed parameter types for `print` and `quick_print` to `_Any`  (builtins.Any from Python) to handle possible unknown typings and very complex unknowable types.
- Reorganized the listing so that types are before enums