### PR TITLE
Doc: Enum Clarifications and Additions

### DIFF
--- a/EN/Strings/code_tooltips.txt
+++ b/EN/Strings/code_tooltips.txt
@@ -131,7 +131,7 @@ example:
 `if get_entity_type() == Entities.Grass:
     harvest()`
 
-See the [`Entities`](docs/home.md) category for a list of available `Entities`.
+See the [`Entities`](docs/home.md) category on the home page for a list of available Entities.
 @code_tooltip_get_ground_type = `get_ground_type()`
 Find out what kind of ground is under the drone.
 
@@ -143,7 +143,7 @@ example:
 `if get_ground_type() != Grounds.Soil:
     till()`
 
-See the [`Grounds`](docs/home.md) category for a list of available `Grounds`.
+See the [`Grounds`](docs/home.md) category on the home page for a list of available Grounds.
 @code_tooltip_get_time = `get_time()`
 Get the current game time.
 
@@ -290,7 +290,7 @@ example:
 `set_execution_speed(1)`
 @code_tooltip_set_world_size = `set_world_size(size)`
 Limits the size of the farm to better see what's happening.
-Also clears the farm, reseting the ground to `Grounds.Grassland` and resets the drone position to (0,0).
+Also clears the farm, resetting the ground to `Grounds.Grassland` and resets the drone position to (0,0).
 Sets the farm to a `size` x `size` grid.
 The smallest `size` possible is `3`.
 A `size` smaller than `3` will change the grid back to its full size.
@@ -313,7 +313,7 @@ example:
 `if num_items(Items.Fertilizer) > 0:
     use_item(Items.Fertilizer)`
 
-See the [`Items`](docs/home.md) category for a list of available `Items`.
+See the [`Items`](docs/home.md) category on the home page for a list of available Items.
 @code_tooltip_get_cost = `get_cost(thing)`
 Gets the cost of a `thing`
 
@@ -331,7 +331,7 @@ for item in cost:
     if num_items(item) < cost[item]:
         print("not enough items to unlock carrots")`
 
-See the [`Unlocks` or `Entities`](docs/home.md) category for a list of available `Unlocks` or `Entities`.
+See the [`Unlocks`](docs/home.md) and [`Entities`](docs/home.md) category on the home page for a list of available Unlocks and Entities.
 @code_tooltip_clear = `clear()`
 Removes everything from the farm, moves the drone back to position `(0,0)` and changes the hat back to the straw hat.
 
@@ -367,7 +367,7 @@ takes `200` ticks to execute if it succeeded, `1` tick otherwise.
 example:
 `unlock(Unlocks.Carrots)`
 
-See the [`Unlocks`](docs/home.md) category for a list of available `Unlocks`.
+See the [`Unlocks`](docs/home.md) category on the home page for a list of available Unlocks.
 @code_tooltip_num_unlocked = `num_unlocked(thing)`
 Used to check if an unlock, entity, ground, item or hat is already unlocked.
 
@@ -380,7 +380,7 @@ example:
 n_substance = get_world_size() * num_unlocked(Unlocks.Mazes)
 use_item(Items.Weird_Substance, n_substance)`
 
-See the [`Unlocks`](docs/home.md) category for a list of available `Unlocks`.
+See the [`Unlocks`](docs/home.md) category on the home page for a list of available Unlocks.
 @code_tooltip_reset = `reset()`
 Resets the farm back to a 1x1 square, removes all resources and locks most unlocks.
 It doesn't remove any of your code.

--- a/EN/Strings/code_tooltips.txt
+++ b/EN/Strings/code_tooltips.txt
@@ -1,5 +1,5 @@
 @code_tooltip_harvest = `harvest()`
-Harvests the entity under the drone. 
+Harvests the entity under the drone.
 If you harvest an entity that can't be harvested, it will be destroyed.
 
 returns `True` if an entity was removed, `False` otherwise.
@@ -9,7 +9,7 @@ takes `200` ticks to execute if an entity was removed, `1` tick otherwise.
 example:
 `harvest()`
 @code_tooltip_can_harvest = `can_harvest()`
-Used to find out if plants are fully grown.
+Used to find out if entities are fully grown.
 
 returns `True` if there is an entity under the drone that is ready to be harvested, `False` otherwise.
 
@@ -28,16 +28,16 @@ takes `1` tick to execute.
 
 example:
 `for i in range(10):
-    print(i)
+print(i)
 
 for i in range(2,6):
-    print(i)
+print(i)
 
 for i in range(10, 0, -1):
-    print(i)`
-@code_tooltip_plant = `plant(entity)` 
+print(i)`
+@code_tooltip_plant = `plant(entity)`
 Spends the cost of the specified `entity` and plants it under the drone.
-It fails if you can't afford the plant, the ground type is wrong or there's already a plant there.
+It fails if you can't afford to plant the `entity`, the ground type is wrong or there's already an existing entity there.
 
 returns `True` if it succeeded, `False` otherwise.
 
@@ -81,8 +81,8 @@ takes `200` ticks to execute on success, `1` tick otherwise.
 
 example:
 `swap(North)`
-@code_tooltip_till = `till()` 
-Tills the ground under the drone into `Grounds.Soil`. If it's already soil it will change the ground back to `Grounds.Grassland`.
+@code_tooltip_till = `till()`
+Tills the ground under the drone into `Grounds.Soil`. If it's already `Grounds.Soil` it will change the ground back to `Grounds.Grassland`.
 
 returns `None`
 
@@ -90,7 +90,7 @@ takes `200` ticks to execute.
 
 example:
 `till()`
-@code_tooltip_get_pos_x = `get_pos_x()` 
+@code_tooltip_get_pos_x = `get_pos_x()`
 Gets the current x position of the drone.
 The x position starts at `0` in the west and increases in the east direction.
 
@@ -100,7 +100,7 @@ takes `1` tick to execute.
 
 example:
 `x, y = get_pos_x(), get_pos_y()`
-@code_tooltip_get_pos_y = `get_pos_y()` 
+@code_tooltip_get_pos_y = `get_pos_y()`
 Gets the current y position of the drone.
 The y position starts at `0` in the south and increases in the north direction.
 
@@ -110,7 +110,7 @@ takes `1` tick to execute.
 
 example:
 `x, y = get_pos_x(), get_pos_y()`
-@code_tooltip_get_world_size = `get_world_size()` 
+@code_tooltip_get_world_size = `get_world_size()`
 Get the current size of the farm.
 
 returns the side length of the grid in the north to south direction.
@@ -120,27 +120,31 @@ takes `1` tick to execute.
 example:
 `for i in range(get_world_size()):
     move(North)`
-@code_tooltip_get_entity_type = `get_entity_type()` 
+@code_tooltip_get_entity_type = `get_entity_type()`
 Find out what kind of entity is under the drone.
 
 returns `None` if the tile is empty, otherwise returns the type of the entity under the drone.
+
+See the [`Entities`](docs/home.md) category for a list of available `Entities`.
 
 takes `1` tick to execute.
 
 example:
 `if get_entity_type() == Entities.Grass:
     harvest()`
-@code_tooltip_get_ground_type = `get_ground_type()` 
+@code_tooltip_get_ground_type = `get_ground_type()`
 Find out what kind of ground is under the drone.
 
 returns the type of the ground under the drone.
+
+See the [`Grounds`](docs/home.md) category for a list of available `Grounds`.
 
 takes `1` tick to execute.
 
 example:
 `if get_ground_type() != Grounds.Soil:
     till()`
-@code_tooltip_get_time = `get_time()` 
+@code_tooltip_get_time = `get_time()`
 Get the current game time.
 
 returns the time in seconds since the start of the game.
@@ -164,16 +168,18 @@ example:
 `do_something()
 
 print(get_tick_count())`
-@code_tooltip_use_item = `use_item(item, n=1)` 
-Attempts to use the specified `item` `n` times. Can only be used with some items including `Items.Water`, `Items.Fertilizer`.
+@code_tooltip_use_item = `use_item(item, n=1)`
+Attempts to use the specified `item` `n` times. Can only be used with some items including:
+- `Items.Water`
+- `Items.Fertilizer`
 
-returns `True` if an item was used, `False` otherwise.
+returns `True` if an `item` was used, `False` otherwise.
 
 takes `200` ticks to execute if it succeeded, `1` tick otherwise.
 
 example:
 `use_item(Items.Fertilizer)`
-@code_tooltip_get_water = `get_water()` 
+@code_tooltip_get_water = `get_water()`
 Get the current water level under the drone.
 
 returns the water level under the drone as a number between `0` and `1`.
@@ -183,7 +189,7 @@ takes `1` tick to execute.
 example:
 `if get_water() < 0.5:
     use_item(Items.Water)`
-@code_tooltip_do_a_flip = `do_a_flip()` 
+@code_tooltip_do_a_flip = `do_a_flip()`
 Makes the drone do a flip! This action is not affected by speed upgrades.
 
 returns `None`
@@ -193,7 +199,7 @@ takes 1s to execute.
 example:
 `while True:
     do_a_flip()`
-@code_tooltip_pet_the_piggy = `pet_the_piggy()` 
+@code_tooltip_pet_the_piggy = `pet_the_piggy()`
 Pets the piggy! This action is not affected by speed upgrades.
 
 returns `None`
@@ -203,7 +209,7 @@ takes 1s to execute.
 example:
 `while True:
     pet_the_piggy()`
-@code_tooltip_print = `print(*args)` 
+@code_tooltip_print = `print(*args)`
 Prints all `args` into the air above the drone using smoke. This action is not affected by speed upgrades.
 Multiple values can be printed at once.
 
@@ -213,7 +219,7 @@ takes 1s to execute.
 
 example:
 `print("ground:", get_ground_type())`
-@code_tooltip_len = `len(collection)` 
+@code_tooltip_len = `len(collection)`
 Get the number of elements in a list, set, dict or tuple.
 
 returns the length of the `collection`.
@@ -224,7 +230,7 @@ example:
 `for i in range(len(list)):
     list[i] += 1`
 @code_tooltip_list = `list(collection = None)`
-Creates a new list. 
+Creates a new list.
 If `collection` is None, it creates an empty list.
 If `collection` is any sequence, it creates a new list with the element of the sequence.
 
@@ -296,7 +302,7 @@ takes `200` ticks to execute.
 
 example:
 `set_world_size(5)`
-@code_tooltip_num_items = `num_items(item)` 
+@code_tooltip_num_items = `num_items(item)`
 Find out how much of `item` you currently have.
 
 returns the number of `item` currently in your inventory.
@@ -306,7 +312,7 @@ takes `1` tick to execute.
 example:
 `if num_items(Items.Fertilizer) > 0:
     use_item(Items.Fertilizer)`
-@code_tooltip_get_cost = `get_cost(thing)` 
+@code_tooltip_get_cost = `get_cost(thing)`
 Gets the cost of a `thing`
 
 If `thing` is an entity get the cost of planting it.
@@ -322,7 +328,7 @@ example:
 for item in cost:
     if num_items(item) < cost[item]:
         print("not enough items to unlock carrots")`
-@code_tooltip_clear = `clear()` 
+@code_tooltip_clear = `clear()`
 Removes everything from the farm, moves the drone back to position `(0,0)` and changes the hat back to the straw hat.
 
 returns `None`
@@ -331,7 +337,7 @@ takes `200` ticks to execute.
 
 example:
 `clear()`
-@code_tooltip_get_companion = `get_companion()` 
+@code_tooltip_get_companion = `get_companion()`
 Get the preferred companion of the plant under the drone.
 
 returns a tuple of the form `(companion_type, (companion_x_position, companion_y_position))`
@@ -343,7 +349,7 @@ example:
 if companion != None:
     plant_type, (x, y) = companion
     print("Companion:", plant_type, "at", x, ",", y)`
-@code_tooltip_unlock = `unlock(unlock)` 
+@code_tooltip_unlock = `unlock(unlock)`
 Has exactly the same effect as clicking the button corresponding to `unlock` in the research tree.
 
 returns `True` if the unlock was successful, `False` otherwise.
@@ -363,7 +369,7 @@ example:
 `plant(Entities.Bush)
 n_substance = get_world_size() * num_unlocked(Unlocks.Mazes)
 use_item(Items.Weird_Substance, n_substance)`
-@code_tooltip_reset = `reset()` 
+@code_tooltip_reset = `reset()`
 Resets the farm back to a 1x1 square, removes all resources and locks most unlocks.
 It doesn't remove any of your code.
 
@@ -373,16 +379,17 @@ takes `200` ticks to execute.
 
 example:
 `reset()`
-@code_tooltip_measure = `measure(direction = None)` 
+@code_tooltip_measure = `measure(direction = None)`
 Can measure some values on some entities. The effect of this depends on the entity.
 
 If `direction` is not `None` it measures the neighboring entity in the given direction.
 
-returns the number of petals of a sunflower.
-returns the next position for a treasure or apple.
-returns the size of a cactus.
-returns a mysterious number for a pumpkin.
-returns `None` for all other entities.
+returns the number of petals of a `Entities.Sunflower`.
+returns the next treasure position of a `Entities.Hedge` or `Entities.Treasure` in a maze.
+returns the next apple location of a `Entities.Apple` during a dinosaur run.
+returns the size of a `Entities.Cactus`.
+returns a mysterious number of a `Entities.Pumpkin`.
+returns `None` for all other entities or an empty tile.
 
 takes `1` tick to execute.
 
@@ -449,11 +456,11 @@ takes `1` tick to execute if the awaited `drone` is already done.
 
 example:
 `def get_entity_type_in_direction(dir):
-    move(dir)
-    return get_entity_type()
+move(dir)
+return get_entity_type()
 
 def zero_arg_wrapper():
-    return get_entity_type_in_direction(North)
+return get_entity_type_in_direction(North)
 handle = spawn_drone(zero_arg_wrapper)
 print(wait_for(handle))`
 
@@ -553,7 +560,7 @@ example:
 `def random_elem(list):
 	index = random() * len(list) // 1
 	return list[index]`
-@code_tooltip_append = `list.append(element)` 
+@code_tooltip_append = `list.append(element)`
 Adds `element` to the end of the `list`.
 
 returns `None`
@@ -563,7 +570,7 @@ takes `1` ticks to execute.
 example:
 `list = []
 list.append(1)`
-@code_tooltip_add = `set.add(element)` 
+@code_tooltip_add = `set.add(element)`
 Adds `element` to the `set`.
 
 returns `None`
@@ -573,7 +580,7 @@ takes `element size` ticks to execute.
 example:
 `set = {0}
 set.add(1)`
-@code_tooltip_remove = `collection.remove(element)` 
+@code_tooltip_remove = `collection.remove(element)`
 Removes the first occurrence of `element` from the `collection`.
 
 returns `None`
@@ -583,7 +590,7 @@ takes `element size` ticks to execute on a set, #comparisions + #shifts ticks on
 example:
 `list = [True, False, None]
 list.remove(False)`
-@code_tooltip_pop = `collection.pop()` 
+@code_tooltip_pop = `collection.pop()`
 Removes the last element from a list or the specified element from a dictionary.
 `list.pop(i)` removes the element at the index `i` from the `list`.
 
@@ -594,7 +601,7 @@ takes `key size` ticks to execute on a dictionary, `len(list) - i + 1` ticks on 
 example:
 `list = [True, False, None]
 list.pop(0)`
-@code_tooltip_insert = `list.insert(i, element)` 
+@code_tooltip_insert = `list.insert(i, element)`
 Inserts `element` into the `list` at index `i`.
 
 returns `None`

--- a/EN/Strings/code_tooltips.txt
+++ b/EN/Strings/code_tooltips.txt
@@ -72,8 +72,7 @@ example:
     move(North)`
 @code_tooltip_swap = `swap(direction)`
 Swaps the entity under the drone with the entity next to the drone in the specified `direction`.
-Doesn't work on all entities.
-Also works if one (or both) of the entities are `None`.
+Will only work on `Entities.Cactus` or if one (or both) of the entities are `None` (nothing is planted on those tiles).
 
 returns `True` if it succeeded, `False` otherwise.
 
@@ -83,6 +82,7 @@ example:
 `swap(North)`
 @code_tooltip_till = `till()`
 Tills the ground under the drone into `Grounds.Soil`. If it's already `Grounds.Soil` it will change the ground back to `Grounds.Grassland`.
+In a fresh run, or when `clear()` is called, the ground starts off as `Grounds.Grassland`.
 
 returns `None`
 
@@ -125,25 +125,25 @@ Find out what kind of entity is under the drone.
 
 returns `None` if the tile is empty, otherwise returns the type of the entity under the drone.
 
-See the [`Entities`](docs/home.md) category for a list of available `Entities`.
-
 takes `1` tick to execute.
 
 example:
 `if get_entity_type() == Entities.Grass:
     harvest()`
+
+See the [`Entities`](docs/home.md) category for a list of available `Entities`.
 @code_tooltip_get_ground_type = `get_ground_type()`
 Find out what kind of ground is under the drone.
 
 returns the type of the ground under the drone.
-
-See the [`Grounds`](docs/home.md) category for a list of available `Grounds`.
 
 takes `1` tick to execute.
 
 example:
 `if get_ground_type() != Grounds.Soil:
     till()`
+
+See the [`Grounds`](docs/home.md) category for a list of available `Grounds`.
 @code_tooltip_get_time = `get_time()`
 Get the current game time.
 
@@ -290,7 +290,7 @@ example:
 `set_execution_speed(1)`
 @code_tooltip_set_world_size = `set_world_size(size)`
 Limits the size of the farm to better see what's happening.
-Also clears the farm and resets the drone position.
+Also clears the farm, reseting the ground to `Grounds.Grassland` and resets the drone position to (0,0).
 Sets the farm to a `size` x `size` grid.
 The smallest `size` possible is `3`.
 A `size` smaller than `3` will change the grid back to its full size.
@@ -312,6 +312,8 @@ takes `1` tick to execute.
 example:
 `if num_items(Items.Fertilizer) > 0:
     use_item(Items.Fertilizer)`
+
+See the [`Items`](docs/home.md) category for a list of available `Items`.
 @code_tooltip_get_cost = `get_cost(thing)`
 Gets the cost of a `thing`
 
@@ -328,6 +330,8 @@ example:
 for item in cost:
     if num_items(item) < cost[item]:
         print("not enough items to unlock carrots")`
+
+See the [`Unlocks` or `Entities`](docs/home.md) category for a list of available `Unlocks` or `Entities`.
 @code_tooltip_clear = `clear()`
 Removes everything from the farm, moves the drone back to position `(0,0)` and changes the hat back to the straw hat.
 
@@ -338,7 +342,11 @@ takes `200` ticks to execute.
 example:
 `clear()`
 @code_tooltip_get_companion = `get_companion()`
-Get the preferred companion of the plant under the drone.
+Get the preferred companion of the plant under the drone. Companions can only include:
+- `Entities.Grass`
+- `Entities.Bush`
+- `Entities.Tree`
+- `Entities.Carrot`
 
 returns a tuple of the form `(companion_type, (companion_x_position, companion_y_position))`
 
@@ -358,6 +366,8 @@ takes `200` ticks to execute if it succeeded, `1` tick otherwise.
 
 example:
 `unlock(Unlocks.Carrots)`
+
+See the [`Unlocks`](docs/home.md) category for a list of available `Unlocks`.
 @code_tooltip_num_unlocked = `num_unlocked(thing)`
 Used to check if an unlock, entity, ground, item or hat is already unlocked.
 
@@ -369,6 +379,8 @@ example:
 `plant(Entities.Bush)
 n_substance = get_world_size() * num_unlocked(Unlocks.Mazes)
 use_item(Items.Weird_Substance, n_substance)`
+
+See the [`Unlocks`](docs/home.md) category for a list of available `Unlocks`.
 @code_tooltip_reset = `reset()`
 Resets the farm back to a 1x1 square, removes all resources and locks most unlocks.
 It doesn't remove any of your code.

--- a/EN/Strings/code_tooltips.txt
+++ b/EN/Strings/code_tooltips.txt
@@ -396,11 +396,11 @@ Can measure some values on some entities. The effect of this depends on the enti
 
 If `direction` is not `None` it measures the neighboring entity in the given direction.
 
-returns the number of petals of a `Entities.Sunflower`.
-returns the next treasure position of a `Entities.Hedge` or `Entities.Treasure` in a maze.
-returns the next apple location of a `Entities.Apple` during a dinosaur run.
-returns the size of a `Entities.Cactus`.
-returns a mysterious number of a `Entities.Pumpkin`.
+<unlock=pumpkins>returns a mysterious number of a `Entities.Pumpkin`.</unlock><unlock=sunflowers>
+returns the number of petals of a `Entities.Sunflower`.</unlock><unlock=cactus>
+returns the size of a `Entities.Cactus`.</unlock><unlock=mazes>
+returns the next treasure position of a `Entities.Hedge` or `Entities.Treasure` in a maze.</unlock><unlock=dinosaurs>
+returns the next apple location of a `Entities.Apple` during a dinosaur run.</unlock>
 returns `None` for all other entities or an empty tile.
 
 takes `1` tick to execute.


### PR DESCRIPTION
# Overview

The premise of this suggestion is to make enum explanations in the help docs clearer, more precise and give obvious callouts about where to find all available enum values. This suggestion also aims to hopefully keep enum value names untranslated by showing them in backtick quotes \` where they are helpful to keep untranslated.

Suggestion thread: https://discord.com/channels/988081966035402783/1506800529706193079

# Pull Request (PR)

The PR is in draft mode because it requires additional translations.

# Hats Missing from Home

There is no Hats category on the home page. This would be helpful to have in order for players to know which hats they have unlocked easily, just like any other enum.

While I could add the code tags for this to the PR, I could not generate them. The markdown for this should be something like:
```
###{{@table_of_contents_section_hats}}
{{hatsTOC}}
```
And having it after the Grounds category would probably make sense.

If this category is added, I would also suggest adding this:
```
See the [`Hats`](docs/home.md) category on the home page for a list of available Hats.
```
To the end of `@code_tooltip_change_hat` in `code_tooltips`

# Measure More Info Clause

The `measure` page has a section for related pages that is either outdated or non-inclusive.

Currently, this is what it says:
```
For more related information see: Sunflowers
```
But it should probably say this if you have all of the related unlocks:
```
For more related information see: Pumpkins, Sunflowers, Cactus, Dinosaurs, or Mazes
```
This seems to be a generated message based on unlock permissions during code run. So I could add a request via the `code_tooltips` file.

## Other Measure Issues

As a side note, `measure` should be available for use for all measurable crops, but it doesn't seem to be usable for pumpkins when you unlock them. It would also be nice if `measure` were usable when either of these is available:
- pumpkins
- sunflowers
- cacti
- maze
- dinosaur
Whenever either of those unlocks is purchased.