### PR TITLE
PT: untranslate the "Variables" unlock name, fix misplaced backticks in tuples.md

### DIFF
--- a/PT/docs/scripting/operators.md
+++ b/PT/docs/scripting/operators.md
@@ -6,7 +6,7 @@ operadores booleanos: `not, and, or`
 Nota: Todos os números no jogo são números de ponto flutuante. Portanto, todos os operadores aritméticos são operadores de ponto flutuante.
 `//` é definido para apenas arredondar o número para baixo após a divisão.
 
-Para operadores de atribuição, você precisa desbloquear o desbloqueio "Variáveis".
+Para operadores de atribuição, você precisa desbloquear "Variables".
 
 ## Introdução
 Operadores permitem que você compare, modifique e combine valores. 

--- a/PT/docs/scripting/tuples.md
+++ b/PT/docs/scripting/tuples.md
@@ -23,7 +23,7 @@ Diferente das listas, tuplas podem ser usadas como chaves em dicionários.
 `d = {(1,2):(4,5)}
 
 print(d[(1,2)])`
-`imprime` (4,5)</unlock>
+imprime `(4,5)`</unlock>
 
 Elas também podem ser úteis para retornar múltiplos valores em uma função.
 


### PR DESCRIPTION
Two small corrections to the Brazilian Portuguese `docs/scripting/` pages.

Both were found while auditing the whole PT localisation (all 16 `docs/scripting/` files and all
14 `Strings/*.txt`) against the English. Worth saying up front: **the PT translation held up very
well.** Placeholders, `@Key` structure, every number and every code span matched the English
exactly, with zero drift. These two are the only concrete errors I found in scope.

I skipped `docs/unlocks/` deliberately, since the README says those files are likely to change.

---

### 1. `PT/docs/scripting/operators.md` - an unlock name is translated

```
EN  For assignment operators you need to unlock the "Variables" unlock.
PT  Para operadores de atribuicao, voce precisa desbloquear o desbloqueio "Variaveis".
```

`Variables` is an unlock name, and the contribution guidelines say:

> Names of items, entities, grounds, unlocks and leaderboards cannot be translated either,
> because things like 'Items.Carrot' are also a part of the code.

As it stands, a player reads *"Variaveis"* and then looks for that in the research tree, where it
is shown as **Variables**. The fix restores the original name. It also drops the doubled
*"desbloquear o desbloqueio"* ("unlock the unlock"), which reads awkwardly in Portuguese.

### 2. `PT/docs/scripting/tuples.md` - backticks on the wrong token

```
EN  `prints` (4,5)
PT  `imprime` (4,5)
```

The backticks sit on the verb rather than on the value, so **"imprime" renders as a code span**.
The same file already does it correctly eleven lines above, where line 16 reads ``imprime `2` ``,
so this just makes the two consistent.

Note the English original has the same misplaced backticks, so you may want to fix `EN/.../tuples.md`
too. I left it alone since this PR is about the Portuguese.

---

Please credit me as **Lucas Ceratto** (@LucasCerattoRS).

Thanks for shipping the docs under CC0 and keeping this repo open - it made it possible to build a
study site for the game from a primary source instead of guesswork.
